### PR TITLE
Fix repo clone URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Cennik Vet is designed for individual veterinarians or small practices that need
 ### 1. Clone & install
 
 ```bash
-git clone https://github.com/andre2630/cennik-vet.git
+git clone https://github.com/andrew2630/cennik-vet.git
 cd cennik-vet
 npm install
 ````


### PR DESCRIPTION
## Summary
- update README's clone instructions to use the correct GitHub URL

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68458641c8408327954d215c08181433