### PR TITLE
Update import button label comment

### DIFF
--- a/src/components/ImportButton.tsx
+++ b/src/components/ImportButton.tsx
@@ -42,7 +42,7 @@ export default function ImportButton({ onFinish }: { onFinish: () => void }) {
         className="flex items-center gap-2 bg-blue-500 hover:bg-blue-600 text-white dark:bg-blue-600 dark:hover:bg-blue-700"
       >
         <Upload className="w-4 h-4" />
-        {t('buttonLabel')} {/* e.g., "Importuj dane" */}
+        {t('buttonLabel')} {/* localized label */}
       </Button>
     </div>
   );


### PR DESCRIPTION
## Summary
- replace the example comment in `ImportButton.tsx` with a neutral label

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845866175408327afc9962e3119e249