### PR TITLE
Add Jest testing

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,9 @@
+import type { Config } from 'jest'
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  testMatch: ['**/tests/**/*.test.ts']
+}
+
+export default config

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "npx serve@latest out",
     "lint": "next lint",
-    "export": "next export"
+    "export": "next export",
+    "test": "jest"
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.3.2",
@@ -69,6 +70,9 @@
     "postcss": "^8.5.4",
     "tailwindcss": "^4.1.8",
     "tw-animate-css": "^1.3.3",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29",
+    "ts-jest": "^29",
+    "@types/jest": "^29"
   }
 }

--- a/src/components/ComboboxGeneric.tsx
+++ b/src/components/ComboboxGeneric.tsx
@@ -22,14 +22,31 @@ interface ComboboxGenericProps {
   onAddNew?: () => void;
 }
 
+export function buildSearchValue(
+  item: Item,
+  displayKey: string,
+  filterKeys?: string[],
+) {
+  const keys = [displayKey, ...(filterKeys ?? [])]
+  return keys
+    .map(k => {
+      const value = item[k]
+      return value !== undefined && value !== null ? String(value) : ''
+    })
+    .join(' ')
+    .trim()
+}
+
 export function ComboboxGeneric({
   items,
   selectedId,
   onSelect,
   placeholder = 'Select...',
   displayKey,
+  filterKeys,
   className = '',
   disabled = false,
+  addNewOption,
   onAddNew
 }: ComboboxGenericProps) {
   const t = useTranslations('combobox');
@@ -64,7 +81,7 @@ export function ComboboxGeneric({
           {items.map(item => (
             <CommandItem
               key={item.id}
-              value={String(item[displayKey])}
+              value={buildSearchValue(item, displayKey, filterKeys)}
               onSelect={() => {
                 if (!disabled) {
                   onSelect(item.id);
@@ -78,7 +95,7 @@ export function ComboboxGeneric({
               {renderBadge(item.type)}
             </CommandItem>
           ))}
-          {onAddNew && (
+          {addNewOption && onAddNew && (
             <CommandItem
               key='__add_new'
               onSelect={() => {

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,0 +1,25 @@
+import { cn } from '../src/lib/utils'
+import { buildSearchValue } from '../src/components/ComboboxGeneric'
+
+describe('cn', () => {
+  it('merges class names', () => {
+    expect(cn('px-2', 'text-sm')).toBe('px-2 text-sm')
+  })
+
+  it('deduplicates conflicting classes', () => {
+    expect(cn('px-2', 'px-4')).toBe('px-4')
+  })
+})
+
+describe('buildSearchValue', () => {
+  const item = { id: '1', name: 'John', address: 'Main', phone: '123' }
+  it('includes display key by default', () => {
+    expect(buildSearchValue(item, 'name')).toBe('John')
+  })
+
+  it('includes additional filter keys', () => {
+    expect(buildSearchValue(item, 'name', ['address', 'phone'])).toBe(
+      'John Main 123'
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- add buildSearchValue helper
- expose filterKeys in ComboboxGeneric
- set up Jest with ts-jest
- add unit tests for `cn` and filtering logic

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684586676d6883278831cedc08c16c90