### PR TITLE
Add filterKeys support in ComboboxGeneric

### DIFF
--- a/src/components/ComboboxGeneric.tsx
+++ b/src/components/ComboboxGeneric.tsx
@@ -9,6 +9,16 @@ import { DialogTitle } from '@/components/ui/dialog';
 import { Item } from '@/types';
 import { useTranslations } from 'next-intl';
 
+export function getSearchValue(
+  item: Item,
+  displayKey: string,
+  filterKeys: string[] = []
+) {
+  return [displayKey, ...filterKeys]
+    .map(key => String(item[key] ?? ''))
+    .join(' ');
+}
+
 interface ComboboxGenericProps {
   items: Item[];
   selectedId: string;
@@ -28,6 +38,7 @@ export function ComboboxGeneric({
   onSelect,
   placeholder = 'Select...',
   displayKey,
+  filterKeys = [],
   className = '',
   disabled = false,
   onAddNew
@@ -55,6 +66,7 @@ export function ComboboxGeneric({
     return null;
   };
 
+
   const List = ({ close }: { close: () => void }) => (
     <Command>
       <CommandInput placeholder={t('search')} disabled={disabled} />
@@ -64,7 +76,7 @@ export function ComboboxGeneric({
           {items.map(item => (
             <CommandItem
               key={item.id}
-              value={String(item[displayKey])}
+              value={getSearchValue(item, displayKey, filterKeys)}
               onSelect={() => {
                 if (!disabled) {
                   onSelect(item.id);

--- a/src/components/__tests__/ComboboxGeneric.test.ts
+++ b/src/components/__tests__/ComboboxGeneric.test.ts
@@ -1,0 +1,18 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { getSearchValue } from '../ComboboxGeneric';
+import type { Item } from '@/types';
+
+describe('getSearchValue', () => {
+  it('includes displayKey value', () => {
+    const item: Item = { id: '1', name: 'Apple' };
+    const result = getSearchValue(item, 'name', ['category']);
+    assert.ok(result.toLowerCase().includes('apple'));
+  });
+
+  it('includes filterKeys values', () => {
+    const item: Item = { id: '1', name: 'Apple', category: 'Fruit' };
+    const result = getSearchValue(item, 'name', ['category']);
+    assert.ok(result.toLowerCase().includes('fruit'));
+  });
+});


### PR DESCRIPTION
## Summary
- extend `ComboboxGeneric` filtering to combine `displayKey` with `filterKeys`
- expose helper `getSearchValue`
- test helper to ensure values from `displayKey` and `filterKeys` are used

## Testing
- `npm run lint` *(fails: `next` not found)*
- `node --test src/components/__tests__/ComboboxGeneric.test.ts` *(fails: unknown file extension .ts)*

------
https://chatgpt.com/codex/tasks/task_e_68458660a1348327a80c17c4064e718d