### PR TITLE
Fix unit display on mobile and PDF

### DIFF
--- a/src/components/TransactionForm.tsx
+++ b/src/components/TransactionForm.tsx
@@ -327,11 +327,11 @@ export default function TransactionForm({
                             const parsed = parseFloat(localQuantities[index].replace(',', '.'));
                             handleItemChange(index, 'quantity', isNaN(parsed) ? 0 : parsed);
                           }}
-                          className={`${readOnly ? 'bg-transparent text-foreground opacity-100 border-none' : ''} w-24`}
+                          className={`${readOnly ? 'bg-transparent text-foreground opacity-100 border-none' : ''} w-24 shrink-0`}
                           disabled={readOnly}
                         />
                       )}
-                      <span className='ml-2 text-muted-foreground'>{product?.unit || ''}</span>
+                      <span className='ml-2 text-muted-foreground whitespace-nowrap'>{product?.unit || ''}</span>
                       {(products.find(p => p.id === item.productId)?.type || 'product') === 'service' && (
                         <span className='ml-2 text-xs font-semibold text-indigo-600 dark:text-indigo-400 bg-indigo-100 dark:bg-indigo-900 px-2 py-0.5 rounded'>
                           {itemTypeT('service')}

--- a/src/utils/pdfExport.ts
+++ b/src/utils/pdfExport.ts
@@ -99,7 +99,7 @@ export async function handleExport(transaction: Transaction, t: ExportLabels) {
           `${index + 1}.`,
           text(product.name),
           item.quantity.toString(),
-          text(product.unit),
+          text(settings.distanceUnit),
           product.pricePerUnit.toFixed(2),
           value.toFixed(2),
         ];


### PR DESCRIPTION
## Summary
- prevent shrinking of quantity input so long units don't overlap
- keep travel unit consistent when exporting PDF

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68458edcdd588327aeaf89e8c512ee60