### PR TITLE
Fix unit display on mobile and data export

### DIFF
--- a/src/components/TransactionForm.tsx
+++ b/src/components/TransactionForm.tsx
@@ -15,6 +15,7 @@ import { Trash } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import ClientModal from '@/components/ClientModal';
 import { getSettings } from '@/utils/settingsStorage';
+import { cnjoin } from '@/lib/utils';
 
 export default function TransactionForm({
   editingTransaction,
@@ -305,7 +306,14 @@ export default function TransactionForm({
                     )}
                   </div>
                   <div className='flex flex-col sm:flex-row sm:items-center sm:justify-between'>
-                    <div className='flex items-center pr-3'>
+                    <div
+                      className={cnjoin(
+                        'flex pr-3',
+                        (product?.unit?.length || 0) > 8
+                          ? 'flex-col items-start sm:flex-row sm:items-center'
+                          : 'items-center'
+                      )}
+                    >
                       <Label className='py-2 mr-2'>{t('quantity')}</Label>
                       {readOnly ? (
                         <div className='text-md'>{item.quantity}</div>
@@ -327,18 +335,43 @@ export default function TransactionForm({
                             const parsed = parseFloat(localQuantities[index].replace(',', '.'));
                             handleItemChange(index, 'quantity', isNaN(parsed) ? 0 : parsed);
                           }}
-                          className={`${readOnly ? 'bg-transparent text-foreground opacity-100 border-none' : ''} w-24`}
+                          className={cnjoin(
+                            readOnly
+                              ? 'bg-transparent text-foreground opacity-100 border-none'
+                              : '',
+                            'w-24',
+                            (product?.unit?.length || 0) > 8 && 'shrink-0'
+                          )}
                           disabled={readOnly}
                         />
                       )}
-                      <span className='ml-2 text-muted-foreground'>{product?.unit || ''}</span>
+                      <span
+                        className={cnjoin(
+                          'text-muted-foreground',
+                          (product?.unit?.length || 0) > 8
+                            ? 'mt-1 sm:mt-0 sm:ml-2 whitespace-nowrap'
+                            : 'ml-2'
+                        )}
+                      >
+                        {product?.unit || ''}
+                      </span>
                       {(products.find(p => p.id === item.productId)?.type || 'product') === 'service' && (
-                        <span className='ml-2 text-xs font-semibold text-indigo-600 dark:text-indigo-400 bg-indigo-100 dark:bg-indigo-900 px-2 py-0.5 rounded'>
+                        <span
+                          className={cnjoin(
+                            'text-xs font-semibold text-indigo-600 dark:text-indigo-400 bg-indigo-100 dark:bg-indigo-900 px-2 py-0.5 rounded',
+                            (product?.unit?.length || 0) > 8 ? 'mt-1 sm:mt-0 sm:ml-2' : 'ml-2'
+                          )}
+                        >
                           {itemTypeT('service')}
                         </span>
                       )}
                       {(products.find(p => p.id === item.productId)?.type || 'product') === 'product' && (
-                        <span className='ml-2 text-xs font-semibold text-lime-600 dark:text-lime-400 bg-lime-100 dark:bg-lime-900 px-2 py-0.5 rounded'>
+                        <span
+                          className={cnjoin(
+                            'text-xs font-semibold text-lime-600 dark:text-lime-400 bg-lime-100 dark:bg-lime-900 px-2 py-0.5 rounded',
+                            (product?.unit?.length || 0) > 8 ? 'mt-1 sm:mt-0 sm:ml-2' : 'ml-2'
+                          )}
+                        >
                           {itemTypeT('product')}
                         </span>
                       )}

--- a/src/components/pages/SettingsPageContent.tsx
+++ b/src/components/pages/SettingsPageContent.tsx
@@ -6,6 +6,7 @@ import { exportAllDataToJSON } from '@/utils/exportStorage';
 import ImportButton from '@/components/ImportButton';
 import { applyTheme, getStoredTheme, Theme } from '@/utils/theme';
 import { Settings as SettingsType, Currency, TravelUnit } from '@/types';
+import { getProducts } from '@/utils/productStorage';
 import { Card, CardContent } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
@@ -15,6 +16,7 @@ import { useTranslations } from 'next-intl';
 
 export default function SettingsPage() {
   const t = useTranslations('settings');
+  const itemTypeT = useTranslations('itemType');
 
   const [settings, setSettings] = useState<SettingsType>({
     currency: 'zł',
@@ -38,6 +40,16 @@ export default function SettingsPage() {
 
     if (field === 'theme') {
       applyTheme(value as Theme);
+    }
+
+    if (field === 'distanceUnit') {
+      const products = getProducts();
+      const travelName = itemTypeT('travel').toLowerCase();
+      const idx = products.findIndex(p => p.name.toLowerCase() === travelName);
+      if (idx !== -1) {
+        products[idx] = { ...products[idx], unit: value as TravelUnit };
+        localStorage.setItem('vet_products', JSON.stringify(products));
+      }
     }
   };
 

--- a/src/utils/exportStorage.ts
+++ b/src/utils/exportStorage.ts
@@ -1,12 +1,21 @@
 import { saveAs } from 'file-saver';
+import pl from '@/public/locales/pl.json';
+import en from '@/public/locales/en.json';
 
 export function exportAllDataToJSON() {
+  const settings = JSON.parse(localStorage.getItem('vet_settings') || '{}');
   const data = {
     products: JSON.parse(localStorage.getItem('vet_products') || '[]'),
     clients: JSON.parse(localStorage.getItem('vet_clients') || '[]'),
     transactions: JSON.parse(localStorage.getItem('vet_transactions') || '[]'),
-    settings: JSON.parse(localStorage.getItem('vet_settings') || '{}'),
+    settings,
   };
+
+  const travelName = (settings.language === 'en' ? en : pl).itemType.travel.toLowerCase();
+
+  data.products = (data.products as any[]).map(p =>
+    p.name.toLowerCase() === travelName ? { ...p, unit: settings.distanceUnit } : p
+  );
 
   const json = JSON.stringify(data, null, 2);
   const blob = new Blob([json], { type: 'application/json' });

--- a/src/utils/pdfExport.ts
+++ b/src/utils/pdfExport.ts
@@ -99,7 +99,7 @@ export async function handleExport(transaction: Transaction, t: ExportLabels) {
           `${index + 1}.`,
           text(product.name),
           item.quantity.toString(),
-          text(product.unit),
+          text(settings.distanceUnit),
           product.pricePerUnit.toFixed(2),
           value.toFixed(2),
         ];


### PR DESCRIPTION
## Summary
- keep quantity input width stable only when the unit name is long
- replace travel product unit with configured distance unit in exported JSON
- update travel product when changing distance unit in settings
- move unit and type labels to a new line for long units on small screens

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68458edcdd588327aeaf89e8c512ee60