### PR TITLE
Open combobox after adding product

### DIFF
--- a/src/components/ComboboxGeneric.tsx
+++ b/src/components/ComboboxGeneric.tsx
@@ -20,6 +20,8 @@ interface ComboboxGenericProps {
   disabled?: boolean;
   addNewOption?: boolean;
   onAddNew?: () => void;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
 export function buildSearchValue(
@@ -47,12 +49,17 @@ export function ComboboxGeneric({
   className = '',
   disabled = false,
   addNewOption,
-  onAddNew
+  onAddNew,
+  open: controlledOpen,
+  onOpenChange
 }: ComboboxGenericProps) {
   const t = useTranslations('combobox');
   const itemTypeT = useTranslations('itemType');
   const isDesktop = useMediaQuery('(min-width: 768px)');
-  const [open, setOpen] = React.useState(false);
+  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(false);
+  const isControlled = controlledOpen !== undefined && onOpenChange !== undefined;
+  const open = isControlled ? controlledOpen : uncontrolledOpen;
+  const setOpen = isControlled ? onOpenChange! : setUncontrolledOpen;
   const selectedItem = items.find(i => i.id === selectedId);
   placeholder = t('select');
 

--- a/src/components/TransactionForm.tsx
+++ b/src/components/TransactionForm.tsx
@@ -43,6 +43,7 @@ export default function TransactionForm({
   const [localQuantities, setLocalQuantities] = useState<string[]>([]);
   const [description, setDescription] = useState('');
   const [isClientModalOpen, setClientModalOpen] = useState(false);
+  const [openItemIndex, setOpenItemIndex] = useState<number | null>(null);
   const { currency } = getSettings();
 
   useEffect(() => {
@@ -151,11 +152,19 @@ export default function TransactionForm({
   };
 
   const handleAddItem = () => {
-    setItems([...items, { productId: '', quantity: 1 }]);
+    setItems(prev => {
+      const newItems = [...prev, { productId: '', quantity: 1 }];
+      setOpenItemIndex(newItems.length - 1);
+      return newItems;
+    });
   };
 
   const handleRemoveItem = (index: number) => {
-    setItems(items.filter((_, i) => i !== index));
+    setItems(prev => {
+      const newItems = prev.filter((_, i) => i !== index);
+      setOpenItemIndex(null);
+      return newItems;
+    });
   };
 
   const handleFinalise = () => {
@@ -290,6 +299,8 @@ export default function TransactionForm({
                             readOnly ? 'pointer-events-none bg-transparent text-foreground opacity-100' : ''
                           }`}
                           disabled={readOnly}
+                          open={openItemIndex === index}
+                          onOpenChange={o => setOpenItemIndex(o ? index : null)}
                         />
                       )}
                     </div>


### PR DESCRIPTION
## Summary
- allow controlling ComboboxGeneric open state
- auto-open product combobox when a new item is added

## Testing
- `npm test` *(fails: `jest` not found)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684596335bf48327b74e5f42a2da0ff3