### PR TITLE
Add mobile install prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - 📄 **PDF export** (with full Polish locale support)
 - 🔌 **Offline support** with **PWA** (via `next-pwa`)
 - ☁️ Works 100% offline (great for home visits)
+- 📲 Suggests installation on mobile for quick "Add to Home Screen"
 - 🌘 **Dark mode** with automatic theme detection
 - 🧾 **Combobox**-based product & client selectors
 - ⚡ Smart auto-saving for drafts

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { SparklesCore } from '@/components/ui/sparkles';
 import HomeButton from '@/components/HomeButton';
 import { Toaster } from 'sonner';
 import BuyMeCoffee from '@/components/BuyMeCoffee';
+import InstallPrompt from '@/components/InstallPrompt';
 
 export const metadata: Metadata = {
   title: 'Cennik Vet',
@@ -46,6 +47,7 @@ export default function RootLayout({
         <Toaster richColors position='top-right' />
         <HomeButton />
         <BuyMeCoffee />
+        <InstallPrompt />
       </body>
     </html>
   );

--- a/src/components/InstallPrompt.tsx
+++ b/src/components/InstallPrompt.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Button } from '@/components/ui/button';
+import { X } from 'lucide-react';
+
+export default function InstallPrompt() {
+  const t = useTranslations('installPrompt');
+  const [deferred, setDeferred] = useState<any>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const handler = (e: any) => {
+      e.preventDefault();
+      setDeferred(e);
+      setVisible(true);
+    };
+    window.addEventListener('beforeinstallprompt', handler);
+    return () => window.removeEventListener('beforeinstallprompt', handler);
+  }, []);
+
+  useEffect(() => {
+    const checkInstalled = () => {
+      if (
+        window.matchMedia('(display-mode: standalone)').matches ||
+        (navigator as any).standalone === true
+      ) {
+        setVisible(false);
+      }
+    };
+    checkInstalled();
+    window.addEventListener('appinstalled', checkInstalled);
+    return () => window.removeEventListener('appinstalled', checkInstalled);
+  }, []);
+
+  const handleInstall = async () => {
+    if (!deferred) return;
+    deferred.prompt();
+    await deferred.userChoice;
+    setDeferred(null);
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div className='fixed bottom-6 left-1/2 -translate-x-1/2 z-50 bg-white dark:bg-gray-900 shadow-lg rounded-md p-4 flex items-center gap-4'>
+      <span className='text-sm'>{t('text')}</span>
+      <Button size='sm' onClick={handleInstall}>{t('install')}</Button>
+      <button onClick={() => setVisible(false)} aria-label={t('dismiss')} className='text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'>
+        <X className='w-4 h-4' />
+      </button>
+    </div>
+  );
+}

--- a/src/public/locales/en.json
+++ b/src/public/locales/en.json
@@ -272,5 +272,10 @@
     "service": "Service",
     "examplePrice": "e.g. 49.99",
     "exampleName": "e.g. Vaccination"
+  },
+  "installPrompt": {
+    "text": "Install this app for offline access?",
+    "install": "Install",
+    "dismiss": "Dismiss"
   }
 }

--- a/src/public/locales/pl.json
+++ b/src/public/locales/pl.json
@@ -272,5 +272,10 @@
     "service": "Usługa",
     "examplePrice": "np. 49.99",
     "exampleName": "np. Szczepienie"
+  },
+  "installPrompt": {
+    "text": "Zainstalować aplikację, aby działała offline?",
+    "install": "Zainstaluj",
+    "dismiss": "Nie teraz"
   }
 }


### PR DESCRIPTION
## Summary
- add `InstallPrompt` component to handle beforeinstallprompt
- register prompt component in the layout
- translate install prompt strings
- mention new install suggestion in README

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a10447b88327a229a93558cc50d8