### PR TITLE
Add BASE_PATH support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,15 @@ npm install
 npm run dev
 ```
 
-Open `http://localhost:3000/cennik-vet/` in your browser.
+Open `http://localhost:3000/cennik-vet/` in your browser. You can override the
+`/cennik-vet` part by setting the `BASE_PATH` environment variable before
+starting the server:
+
+```bash
+BASE_PATH=/my-dev-path npm run dev
+```
+
+Then visit `http://localhost:3000/my-dev-path/`.
 
 ---
 
@@ -61,7 +69,14 @@ npm run build
 npm start
 ```
 
-App is exported to `out/` folder and served statically.
+App is exported to the `out/` folder and served statically. You can set a
+different base path during the build step using `BASE_PATH`:
+
+```bash
+BASE_PATH=/my-dev-path npm run build
+```
+
+The exported site will then expect to be hosted under that path.
 
 ---
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,10 +3,12 @@ import withPWA from 'next-pwa';
 
 const withNextIntl = require('next-intl/plugin')('./i18n.ts');
 
+const basePath = process.env.BASE_PATH || '/cennik-vet';
+
 const baseConfig: NextConfig = {
   reactStrictMode: true,
   output: 'export',
-  basePath: '/cennik-vet',
+  basePath,
   trailingSlash: true,
 };
 


### PR DESCRIPTION
## Summary
- allow overriding Next.js `basePath` via `BASE_PATH` env variable
- document how to run dev server and build with custom path

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845df6c4aa48327bb13e37d812c46bd