### PR TITLE
Remove explicit any usages

### DIFF
--- a/src/components/InstallPrompt.tsx
+++ b/src/components/InstallPrompt.tsx
@@ -7,11 +7,11 @@ import { X } from 'lucide-react';
 
 export default function InstallPrompt() {
   const t = useTranslations('installPrompt');
-  const [deferred, setDeferred] = useState<any>(null);
+  const [deferred, setDeferred] = useState<BeforeInstallPromptEvent | null>(null);
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
-    const handler = (e: any) => {
+    const handler = (e: BeforeInstallPromptEvent) => {
       e.preventDefault();
       setDeferred(e);
       setVisible(true);
@@ -24,7 +24,7 @@ export default function InstallPrompt() {
     const checkInstalled = () => {
       if (
         window.matchMedia('(display-mode: standalone)').matches ||
-        (navigator as any).standalone === true
+        navigator.standalone === true
       ) {
         setVisible(false);
       }

--- a/src/types/pwa.d.ts
+++ b/src/types/pwa.d.ts
@@ -1,0 +1,16 @@
+export {};
+
+declare global {
+  interface BeforeInstallPromptEvent extends Event {
+    readonly platforms?: string[];
+    prompt: () => Promise<void>;
+    userChoice: Promise<{
+      outcome: 'accepted' | 'dismissed';
+      platform: string;
+    }>;
+  }
+
+  interface Navigator {
+    standalone?: boolean;
+  }
+}


### PR DESCRIPTION
## Summary
- avoid `any` in InstallPrompt
- add PWA types to cover global interfaces

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ea8264d0832780f1d4ddeda4b763