### PR TITLE
Handle basePath in manifest & layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,15 @@ npm install
 npm run dev
 ```
 
-Open `http://localhost:3000/cennik-vet/` in your browser.
+Open `http://localhost:3000/cennik-vet/` in your browser. You can override the
+`/cennik-vet` part by setting the `BASE_PATH` environment variable before
+starting the server:
+
+```bash
+BASE_PATH=/my-dev-path npm run dev
+```
+
+Then visit `http://localhost:3000/my-dev-path/`.
 
 ---
 
@@ -61,7 +69,14 @@ npm run build
 npm start
 ```
 
-App is exported to `out/` folder and served statically.
+App is exported to the `out/` folder and served statically. You can set a
+different base path during the build step using `BASE_PATH`:
+
+```bash
+BASE_PATH=/my-dev-path npm run build
+```
+
+The exported site will then expect to be hosted under that path.
 
 ---
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,10 +3,15 @@ import withPWA from 'next-pwa';
 
 const withNextIntl = require('next-intl/plugin')('./i18n.ts');
 
+const basePath = process.env.BASE_PATH || '/cennik-vet';
+
 const baseConfig: NextConfig = {
   reactStrictMode: true,
   output: 'export',
-  basePath: '/cennik-vet',
+  basePath,
+  env: {
+    NEXT_PUBLIC_BASE_PATH: basePath,
+  },
   trailingSlash: true,
 };
 

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,8 +1,8 @@
 {
   "name": "Cennik Vet",
   "short_name": "Cennik Vet",
-  "start_url": "/cennik-vet/",
-  "scope": "/cennik-vet/",
+  "start_url": "./",
+  "scope": "./",
   "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#0A0A0A",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -38,8 +38,15 @@ export default function RootLayout({
             `,
           }}
         />
-        <link rel='manifest' href='/cennik-vet/manifest.json' />
-        <link rel='apple-touch-icon' href='/cennik-vet/icon-192.png' />
+        {(() => {
+          const base = process.env.NEXT_PUBLIC_BASE_PATH || '/cennik-vet';
+          return (
+            <>
+              <link rel='manifest' href={`${base}/manifest.json`} />
+              <link rel='apple-touch-icon' href={`${base}/icon-192.png`} />
+            </>
+          );
+        })()}
         <meta name='theme-color' content='#0A0A0A' />
       </head>
       <body className='min-h-screen bg-white dark:bg-gray-900 text-black dark:text-white font-sans antialiased'>


### PR DESCRIPTION
## Summary
- expose `NEXT_PUBLIC_BASE_PATH` from `next.config.ts`
- update layout to use this env var for manifest and icons
- use relative `start_url` and `scope` in manifest

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845df6c4aa48327bb13e37d812c46bd