### PR TITLE
Fix custom unit display in product edit

### DIFF
--- a/src/components/ProductForm.tsx
+++ b/src/components/ProductForm.tsx
@@ -41,7 +41,14 @@ export default function ProductForm({ onAdd }: { onAdd: () => void }) {
       const product = getProducts().find(p => p.id === productId);
       if (product) {
         setName(product.name);
-        setUnit(product.unit);
+        if (predefinedUnits.includes(product.unit)) {
+          setUnit(product.unit);
+          setIsCustomUnit(false);
+          setCustomUnit('');
+        } else {
+          setCustomUnit(product.unit);
+          setIsCustomUnit(true);
+        }
         setPrice(product.pricePerUnit.toString());
         setType(product.type);
       }


### PR DESCRIPTION
## Summary
- populate custom unit value when editing a product

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68468dc51bc083279fe1764432ebb163