### PR TITLE
Add supabase auth and sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,22 @@ Deploy via any static host:
 
 ---
 
+## ☁️ Supabase Sync
+
+1. Create a new [Supabase](https://supabase.com/) project and note the `SUPABASE_URL` and `SUPABASE_ANON_KEY` values.
+2. In the project, create tables named `products`, `clients` and `transactions`. Each table should contain all fields from the local models and a `user_id` column of type `uuid`.
+3. Enable Row Level Security on each table and add a policy to allow users to access rows where `user_id = auth.uid()`.
+4. In your `.env` file expose these keys to the frontend:
+
+```bash
+NEXT_PUBLIC_SUPABASE_URL=<your url>
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<your key>
+```
+
+When you sign in from the Settings page the app will sync any queued changes to Supabase whenever you are online.
+
+---
+
 ## 📁 Project Structure
 
 ```

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "tsparticles-slim": "^2.12.0",
     "use-debounce": "^10.0.4",
     "uuid": "^11.1.0",
-    "vaul": "^1.1.2"
+    "vaul": "^1.1.2",
+    "@supabase/supabase-js": "^2.39.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/public/locales/en.json
+++ b/src/public/locales/en.json
@@ -158,7 +158,11 @@
     "distance": "Distance Unit",
     "distanceKm": "Kilometer",
     "distanceMi": "Mile",
-    "export": "Export Data"
+    "export": "Export Data",
+    "login": "Log in",
+    "register": "Register",
+    "logout": "Log out",
+    "loggedIn": "Logged in"
   },
   "transactionsList": {
     "unknownClient": "Unknown client",

--- a/src/public/locales/pl.json
+++ b/src/public/locales/pl.json
@@ -158,7 +158,11 @@
     "distance": "Jednostka dystansu",
     "distanceKm": "Kilometr",
     "distanceMi": "Mila",
-    "export": "Eksportuj dane"
+    "export": "Eksportuj dane",
+    "login": "Zaloguj",
+    "register": "Rejestracja",
+    "logout": "Wyloguj",
+    "loggedIn": "Zalogowany"
   },
   "transactionsList": {
     "unknownClient": "Nieznany klient",

--- a/src/utils/clientStorage.ts
+++ b/src/utils/clientStorage.ts
@@ -1,4 +1,5 @@
 import { Client } from '@/types';
+import { queueOperation } from './syncSupabase';
 
 const STORAGE_KEY = 'vet_clients';
 
@@ -13,9 +14,11 @@ export function saveClient(client: Client) {
   const index = all.findIndex(p => p.id === client.id);
   const updated = index !== -1 ? [...all.slice(0, index), client, ...all.slice(index + 1)] : [...all, client];
   localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+  queueOperation({ type: 'upsert', table: 'clients', data: client });
 }
 
 export function deleteClient(id: string): void {
   const clients = getClients().filter(c => c.id !== id);
   localStorage.setItem(STORAGE_KEY, JSON.stringify(clients));
+  queueOperation({ type: 'delete', table: 'clients', id });
 }

--- a/src/utils/productStorage.ts
+++ b/src/utils/productStorage.ts
@@ -1,4 +1,5 @@
 import { Product } from '@/types';
+import { queueOperation } from './syncSupabase';
 
 const STORAGE_KEY = 'vet_products';
 
@@ -15,9 +16,11 @@ export function saveProduct(product: Product) {
   const index = all.findIndex(p => p.id === product.id);
   const updated = index !== -1 ? [...all.slice(0, index), product, ...all.slice(index + 1)] : [...all, product];
   localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+  queueOperation({ type: 'upsert', table: 'products', data: product });
 }
 
 export function deleteProduct(id: string): void {
   const products = getProducts().filter(p => p.id !== id);
   localStorage.setItem(STORAGE_KEY, JSON.stringify(products));
+  queueOperation({ type: 'delete', table: 'products', id });
 }

--- a/src/utils/supabaseClient.ts
+++ b/src/utils/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || ''
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ''
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey)

--- a/src/utils/syncSupabase.ts
+++ b/src/utils/syncSupabase.ts
@@ -1,0 +1,48 @@
+import { supabase } from './supabaseClient'
+import { Client, Product, Transaction } from '@/types'
+
+interface Operation {
+  type: 'upsert' | 'delete'
+  table: 'products' | 'clients' | 'transactions'
+  data?: Product | Client | Transaction
+  id?: string
+}
+
+const QUEUE_KEY = 'vet_supabase_queue'
+
+function getQueue(): Operation[] {
+  try {
+    return JSON.parse(localStorage.getItem(QUEUE_KEY) || '[]') as Operation[]
+  } catch {
+    return []
+  }
+}
+
+function saveQueue(queue: Operation[]) {
+  localStorage.setItem(QUEUE_KEY, JSON.stringify(queue))
+}
+
+export function queueOperation(op: Operation) {
+  const queue = getQueue()
+  queue.push(op)
+  saveQueue(queue)
+}
+
+export async function syncQueue(userId: string) {
+  if (!navigator.onLine) return
+
+  const queue = getQueue()
+  for (const op of queue) {
+    try {
+      if (op.type === 'upsert' && op.data) {
+        await supabase.from(op.table).upsert({ ...op.data, user_id: userId })
+      } else if (op.type === 'delete' && op.id) {
+        await supabase.from(op.table).delete().eq('id', op.id)
+      }
+    } catch (e) {
+      console.error('Supabase sync error', e)
+      return
+    }
+  }
+  saveQueue([])
+}

--- a/src/utils/transactionStorage.ts
+++ b/src/utils/transactionStorage.ts
@@ -1,4 +1,5 @@
 import { Transaction } from '@/types';
+import { queueOperation } from './syncSupabase';
 import { v4 as uuid } from 'uuid';
 
 const STORAGE_KEY = 'vet_transactions';
@@ -26,6 +27,7 @@ export function saveTransaction(tx: Transaction): Transaction {
   }
 
   localStorage.setItem(STORAGE_KEY, JSON.stringify(all));
+  queueOperation({ type: 'upsert', table: 'transactions', data: transactionToSave });
   return transactionToSave;
 }
 
@@ -36,4 +38,5 @@ export function updateTransaction(tx: Transaction): Transaction {
 export function deleteTransaction(id: string): void {
   const filtered = getTransactions().filter((t) => t.id !== id);
   localStorage.setItem(STORAGE_KEY, JSON.stringify(filtered));
+  queueOperation({ type: 'delete', table: 'transactions', id });
 }

--- a/src/utils/useSupabaseAuth.ts
+++ b/src/utils/useSupabaseAuth.ts
@@ -1,0 +1,28 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { supabase } from './supabaseClient'
+import type { User } from '@supabase/supabase-js'
+
+export function useSupabaseAuth() {
+  const [user, setUser] = useState<User | null>(null)
+
+  useEffect(() => {
+    supabase.auth.getUser().then(res => setUser(res.data.user ?? null))
+    const { data } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null)
+    })
+    return () => {
+      data.subscription.unsubscribe()
+    }
+  }, [])
+
+  const signIn = (email: string, password: string) =>
+    supabase.auth.signInWithPassword({ email, password })
+
+  const signUp = (email: string, password: string) =>
+    supabase.auth.signUp({ email, password })
+
+  const signOut = () => supabase.auth.signOut()
+
+  return { user, signIn, signUp, signOut }
+}


### PR DESCRIPTION
## Summary
- integrate Supabase client and auth hook
- queue offline operations and sync when online
- expose login form on settings page
- document Supabase configuration

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b2e239208327b01153ac70209e39