### PR TITLE
Fix PWA paths and Supabase auth handling

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -9,19 +9,19 @@
   "orientation": "portrait",
   "icons": [
     {
-      "src": "/icon-192.png",
+      "src": "icon-192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "/icon-512.png",
+      "src": "icon-512.png",
       "sizes": "512x512",
       "type": "image/png"
     }
   ],
   "screenshots": [
     {
-      "src": "/screenshots/home.png",
+      "src": "screenshots/home.png",
       "sizes": "540x720",
       "type": "image/png",
       "form_factor": "wide"

--- a/src/components/pages/SettingsPageContent.tsx
+++ b/src/components/pages/SettingsPageContent.tsx
@@ -64,23 +64,23 @@ export default function SettingsPage() {
   };
 
   const handleLogin = async () => {
-    const { error } = await signIn(email, password);
+    const { error } = await signIn(email.trim(), password);
     if (!error) {
       toast.success(authT('loginSuccess'));
       const { data } = await supabase.auth.getUser();
       if (data.user) await syncQueue(data.user.id);
     } else {
-      toast.error(authT('loginError'));
+      toast.error(error.message || authT('loginError'));
     }
   };
 
   const handleRegister = async () => {
-    const { error } = await signUp(email, password);
+    const { error } = await signUp(email.trim(), password);
     if (!error) {
       toast.success(authT('registerSuccess'));
       await handleLogin();
     } else {
-      toast.error(authT('registerError'));
+      toast.error(error.message || authT('registerError'));
     }
   };
 

--- a/src/utils/supabaseClient.ts
+++ b/src/utils/supabaseClient.ts
@@ -3,4 +3,8 @@ import { createClient } from '@supabase/supabase-js'
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || ''
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ''
 
+if (!supabaseUrl || !supabaseAnonKey) {
+  console.warn('Supabase environment variables are missing')
+}
+
 export const supabase = createClient(supabaseUrl, supabaseAnonKey)

--- a/src/utils/useSupabaseAuth.ts
+++ b/src/utils/useSupabaseAuth.ts
@@ -27,10 +27,10 @@ export function useSupabaseAuth() {
   }, [user])
 
   const signIn = (email: string, password: string) =>
-    supabase.auth.signInWithPassword({ email, password })
+    supabase.auth.signInWithPassword({ email: email.trim(), password })
 
   const signUp = (email: string, password: string) =>
-    supabase.auth.signUp({ email, password })
+    supabase.auth.signUp({ email: email.trim(), password })
 
   const signOut = () => supabase.auth.signOut()
 


### PR DESCRIPTION
## Summary
- fix manifest icon paths so they honour BASE_PATH
- warn if Supabase env vars are missing
- trim login credentials and surface Supabase error messages

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846c4bec0a08327989f7fd51618ef87