### PR TITLE
Fix auto-sync after queueing operations

### DIFF
--- a/src/utils/syncSupabase.ts
+++ b/src/utils/syncSupabase.ts
@@ -22,10 +22,18 @@ function saveQueue(queue: Operation[]) {
   localStorage.setItem(QUEUE_KEY, JSON.stringify(queue))
 }
 
-export function queueOperation(op: Operation) {
+export async function queueOperation(op: Operation) {
   const queue = getQueue()
   queue.push(op)
   saveQueue(queue)
+
+  try {
+    const { data } = await supabase.auth.getUser()
+    const userId = data.user?.id
+    if (userId) await syncQueue(userId)
+  } catch (e) {
+    console.error('Supabase auto-sync error', e)
+  }
 }
 
 export async function syncQueue(userId: string) {


### PR DESCRIPTION
## Summary
- trigger Supabase synchronization automatically whenever a queue operation is added

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6846d29d825c8327a7bb4bce42095bc7