### PR TITLE
Fix sync not triggered after login

### DIFF
--- a/src/utils/useSupabaseAuth.ts
+++ b/src/utils/useSupabaseAuth.ts
@@ -21,6 +21,7 @@ export function useSupabaseAuth() {
     if (!user) return
     const handleOnline = () => syncQueue(user.id)
     window.addEventListener('online', handleOnline)
+    syncQueue(user.id)
     return () => {
       window.removeEventListener('online', handleOnline)
     }


### PR DESCRIPTION
## Summary
- sync queued operations immediately upon login

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d62f402c83279c747069be777abe