### PR TITLE
Fix Supabase sync order

### DIFF
--- a/src/utils/syncSupabase.ts
+++ b/src/utils/syncSupabase.ts
@@ -69,6 +69,13 @@ export async function syncQueue(userId: string) {
 
   try {
     const queue = getQueue()
+    const priority: Record<Operation['table'], number> = {
+      products: 0,
+      clients: 1,
+      transactions: 2,
+    }
+    queue.sort((a, b) => priority[a.table] - priority[b.table])
+    saveQueue(queue)
     while (queue.length > 0) {
       const op = queue[0]
       try {


### PR DESCRIPTION
## Summary
- ensure Supabase queue processes clients before transactions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846e83c92688327bdcdc3b9c718c04a