### PR TITLE
Fix transaction sync ordering

### DIFF
--- a/src/utils/syncSupabase.ts
+++ b/src/utils/syncSupabase.ts
@@ -48,8 +48,15 @@ export async function queueOperation(op: Operation) {
   if (typeof window === 'undefined') return
 
   const queue = getQueue()
-  queue.push(op)
-  saveQueue(queue)
+  const opId = op.data ? (op.data as { id: string }).id : op.id
+
+  const updatedQueue = queue.filter(q => {
+    const qId = q.data ? (q.data as { id: string }).id : q.id
+    return !(q.table === op.table && qId === opId)
+  })
+
+  updatedQueue.push(op)
+  saveQueue(updatedQueue)
 
   try {
     const { data } = await supabase.auth.getUser()

--- a/src/utils/transactionStorage.ts
+++ b/src/utils/transactionStorage.ts
@@ -27,7 +27,13 @@ export function saveTransaction(tx: Transaction): Transaction {
   }
 
   localStorage.setItem(STORAGE_KEY, JSON.stringify(all));
-  queueOperation({ type: 'upsert', table: 'transactions', data: transactionToSave });
+  if (transactionToSave.clientId) {
+    queueOperation({
+      type: 'upsert',
+      table: 'transactions',
+      data: transactionToSave,
+    })
+  }
   return transactionToSave;
 }
 


### PR DESCRIPTION
## Summary
- avoid queuing transactions without a client
- replace previous operations in sync queue

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846f0ececa083278733ee3fce1261a1