### PR TITLE
Fix hydration mismatch in settings page

### DIFF
--- a/src/components/PageWrapper.tsx
+++ b/src/components/PageWrapper.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import { NextIntlClientProvider } from 'next-intl';
 import pl from '@/public/locales/pl.json';
 import en from '@/public/locales/en.json';
@@ -7,9 +8,16 @@ import { getSettings } from '@/utils/settingsStorage';
 import Theme from '@/components/Theme';
 
 export default function PageWrapper({ children }: { children: React.ReactNode }) {
-  const lang = getSettings().language;
+  const [lang, setLang] = useState<'pl' | 'en'>('pl');
+
+  useEffect(() => {
+    setLang(getSettings().language);
+  }, []);
+
+  const messages = lang === 'pl' ? pl : en;
+
   return (
-    <NextIntlClientProvider messages={lang === 'pl' ? pl : en} locale={lang} timeZone='Europe/Warsaw'>
+    <NextIntlClientProvider messages={messages} locale={lang} timeZone='Europe/Warsaw'>
       <Theme>{children}</Theme>
     </NextIntlClientProvider>
   );


### PR DESCRIPTION
## Summary
- handle localStorage-based language selection in `PageWrapper` using state

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846effd2e84832796531430b093c2bb