### PR TITLE
Add periodic Supabase sync and auto refresh

### DIFF
--- a/src/components/pages/CalendarPageContent.tsx
+++ b/src/components/pages/CalendarPageContent.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import useDataUpdate from '@/utils/useDataUpdate';
 import { getTransactions } from '@/utils/transactionStorage';
 import { getClients } from '@/utils/clientStorage';
 import { Transaction, Client } from '@/types';
@@ -20,13 +21,14 @@ export default function CalendarPage() {
   const [currentDate, setCurrentDate] = useState(new Date());
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const router = useRouter();
+  const refresh = useDataUpdate();
 
   const dateFnsLocale = locale === 'pl' ? pl : enUS;
 
   useEffect(() => {
     setTransactions(getTransactions());
     setClients(getClients());
-  }, []);
+  }, [refresh]);
 
   const formatDate = (date: Date) => date.toLocaleDateString('sv-SE'); // ISO-like YYYY-MM-DD
 

--- a/src/components/pages/ClientsPageContent.tsx
+++ b/src/components/pages/ClientsPageContent.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import useDataUpdate from '@/utils/useDataUpdate';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import ClientList from '@/components/ClientList';
@@ -9,7 +9,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 
 export default function ClientsPage() {
-  const [refresh] = useState(0);
+  const refresh = useDataUpdate();
   const t = useTranslations('clientsPage');
 
   return (

--- a/src/components/pages/DashboardHome.tsx
+++ b/src/components/pages/DashboardHome.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import useDataUpdate from '@/utils/useDataUpdate';
 import Link from 'next/link';
 import dayjs from 'dayjs';
 import CountUp from 'react-countup';
@@ -33,6 +34,7 @@ import { getSettings } from '@/utils/settingsStorage';
 export default function DashboardHome() {
   const t = useTranslations('dashboard');
   const itemTypeT = useTranslations('itemType');
+  const refresh = useDataUpdate();
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [products, setProducts] = useState<Product[]>([]);
   const [clients, setClients] = useState<Client[]>([]);
@@ -45,7 +47,7 @@ export default function DashboardHome() {
     setTransactions(getTransactions());
     setProducts(getProducts());
     setClients(getClients());
-  }, []);
+  }, [refresh]);
 
   const getClientName = (id: string) => clients.find(c => c.id === id)?.name || 'Nieznany klient';
 

--- a/src/components/pages/ProductsPageContent.tsx
+++ b/src/components/pages/ProductsPageContent.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import useDataUpdate from '@/utils/useDataUpdate';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 import ProductList from '@/components/ProductList';
@@ -9,7 +9,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 
 export default function ProductsPage() {
-  const [refresh] = useState(0);
+  const refresh = useDataUpdate();
   const t = useTranslations('products');
 
   return (

--- a/src/components/pages/SettingsPageContent.tsx
+++ b/src/components/pages/SettingsPageContent.tsx
@@ -7,6 +7,7 @@ import ImportButton from '@/components/ImportButton';
 import { applyTheme, getStoredTheme, Theme } from '@/utils/theme';
 import { Settings as SettingsType, Currency, TravelUnit } from '@/types';
 import { getProducts } from '@/utils/productStorage';
+import { notifyDataUpdated } from '@/utils/dataUpdateEvent';
 import { useSupabaseAuth } from '@/utils/useSupabaseAuth';
 import { syncQueue, downloadUserData } from '@/utils/syncSupabase';
 import { supabase } from '@/utils/supabaseClient';
@@ -83,6 +84,7 @@ export default function SettingsPage() {
       if (idx !== -1) {
         products[idx] = { ...products[idx], unit: value as TravelUnit };
         localStorage.setItem('vet_products', JSON.stringify(products));
+        notifyDataUpdated();
       }
     }
   };

--- a/src/components/pages/TransactionsPageContent.tsx
+++ b/src/components/pages/TransactionsPageContent.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { Suspense, useState } from 'react';
+import { Suspense } from 'react';
+import useDataUpdate from '@/utils/useDataUpdate';
 import Link from 'next/link';
 import { PlusCircle, ReceiptText } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -9,7 +10,7 @@ import TransactionList from '@/components/TransactionList';
 import { useTranslations } from 'next-intl';
 
 export default function TransactionsPage() {
-  const [refresh] = useState(0);
+  const refresh = useDataUpdate();
   const t = useTranslations('transactions');
 
   return (

--- a/src/utils/clientStorage.ts
+++ b/src/utils/clientStorage.ts
@@ -1,5 +1,6 @@
 import { Client } from '@/types';
 import { queueOperation } from './syncSupabase';
+import { notifyDataUpdated } from './dataUpdateEvent';
 import { getTransactions, deleteTransaction } from './transactionStorage';
 
 const STORAGE_KEY = 'vet_clients';
@@ -19,12 +20,14 @@ export function saveClient(client: Client) {
       ? [...all.slice(0, index), clientToSave, ...all.slice(index + 1)]
       : [...all, clientToSave];
   localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+  notifyDataUpdated();
   queueOperation({ type: 'upsert', table: 'clients', data: clientToSave });
 }
 
 export function deleteClient(id: string): void {
   const clients = getClients().filter(c => c.id !== id);
   localStorage.setItem(STORAGE_KEY, JSON.stringify(clients));
+  notifyDataUpdated();
 
   const toDelete = getTransactions().filter(t => t.clientId === id);
   toDelete.forEach(t => deleteTransaction(t.id));

--- a/src/utils/dataUpdateEvent.ts
+++ b/src/utils/dataUpdateEvent.ts
@@ -1,0 +1,7 @@
+export const DATA_UPDATED_EVENT = 'dataUpdated'
+
+export function notifyDataUpdated() {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new Event(DATA_UPDATED_EVENT))
+  }
+}

--- a/src/utils/importStorage.ts
+++ b/src/utils/importStorage.ts
@@ -3,6 +3,7 @@
 import { toast } from 'sonner';
 import { queueOperation, syncQueue } from './syncSupabase';
 import { supabase } from './supabaseClient';
+import { notifyDataUpdated } from './dataUpdateEvent';
 import type { Product, Client, Transaction } from '@/types';
 
 export function importAllDataFromJSON(
@@ -26,6 +27,7 @@ export function importAllDataFromJSON(
           updatedAt: p.updatedAt || new Date().toISOString(),
         }))
         localStorage.setItem('vet_products', JSON.stringify(productsWithDates))
+        notifyDataUpdated()
         productsWithDates.forEach(p =>
           queueOperation({ type: 'upsert', table: 'products', data: p })
         )
@@ -36,6 +38,7 @@ export function importAllDataFromJSON(
           updatedAt: c.updatedAt || new Date().toISOString(),
         }))
         localStorage.setItem('vet_clients', JSON.stringify(clientsWithDates))
+        notifyDataUpdated()
         clientsWithDates.forEach(c =>
           queueOperation({ type: 'upsert', table: 'clients', data: c })
         )
@@ -46,6 +49,7 @@ export function importAllDataFromJSON(
           updatedAt: t.updatedAt || new Date().toISOString(),
         }))
         localStorage.setItem('vet_transactions', JSON.stringify(transactionsWithDates))
+        notifyDataUpdated()
         transactionsWithDates.forEach(t =>
           queueOperation({ type: 'upsert', table: 'transactions', data: t })
         )

--- a/src/utils/productStorage.ts
+++ b/src/utils/productStorage.ts
@@ -1,5 +1,6 @@
 import { Product } from '@/types';
 import { queueOperation } from './syncSupabase';
+import { notifyDataUpdated } from './dataUpdateEvent';
 
 const STORAGE_KEY = 'vet_products';
 
@@ -20,11 +21,13 @@ export function saveProduct(product: Product) {
       ? [...all.slice(0, index), productToSave, ...all.slice(index + 1)]
       : [...all, productToSave];
   localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+  notifyDataUpdated();
   queueOperation({ type: 'upsert', table: 'products', data: productToSave });
 }
 
 export function deleteProduct(id: string): void {
   const products = getProducts().filter(p => p.id !== id);
   localStorage.setItem(STORAGE_KEY, JSON.stringify(products));
+  notifyDataUpdated();
   queueOperation({ type: 'delete', table: 'products', id });
 }

--- a/src/utils/syncSupabase.ts
+++ b/src/utils/syncSupabase.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { supabase } from './supabaseClient'
+import { notifyDataUpdated } from './dataUpdateEvent'
 import { Client, Product, Transaction } from '@/types'
 
 function snakeCaseKeys<T extends Record<string, unknown>>(obj: T): Record<string, unknown> {
@@ -193,6 +194,7 @@ export async function downloadUserData(userId: string) {
     localStorage.setItem('vet_products', JSON.stringify(mergedProducts))
     localStorage.setItem('vet_clients', JSON.stringify(mergedClients))
     localStorage.setItem('vet_transactions', JSON.stringify(mergedTransactions))
+    notifyDataUpdated()
   } catch (e) {
     console.error('Supabase download error', e)
   }

--- a/src/utils/transactionStorage.ts
+++ b/src/utils/transactionStorage.ts
@@ -1,5 +1,6 @@
 import { Transaction } from '@/types';
 import { queueOperation } from './syncSupabase';
+import { notifyDataUpdated } from './dataUpdateEvent';
 import { v4 as uuid } from 'uuid';
 
 const STORAGE_KEY = 'vet_transactions';
@@ -28,6 +29,7 @@ export function saveTransaction(tx: Transaction): Transaction {
   }
 
   localStorage.setItem(STORAGE_KEY, JSON.stringify(all));
+  notifyDataUpdated();
   if (transactionToSave.clientId) {
     queueOperation({
       type: 'upsert',
@@ -45,5 +47,6 @@ export function updateTransaction(tx: Transaction): Transaction {
 export function deleteTransaction(id: string): void {
   const filtered = getTransactions().filter((t) => t.id !== id);
   localStorage.setItem(STORAGE_KEY, JSON.stringify(filtered));
+  notifyDataUpdated();
   queueOperation({ type: 'delete', table: 'transactions', id });
 }

--- a/src/utils/useDataUpdate.ts
+++ b/src/utils/useDataUpdate.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react'
+import { DATA_UPDATED_EVENT } from './dataUpdateEvent'
+
+export default function useDataUpdate() {
+  const [version, setVersion] = useState(0)
+
+  useEffect(() => {
+    const handler = () => setVersion(v => v + 1)
+    window.addEventListener(DATA_UPDATED_EVENT, handler)
+    return () => window.removeEventListener(DATA_UPDATED_EVENT, handler)
+  }, [])
+
+  return version
+}

--- a/src/utils/useSupabaseAuth.ts
+++ b/src/utils/useSupabaseAuth.ts
@@ -19,17 +19,17 @@ export function useSupabaseAuth() {
 
   useEffect(() => {
     if (!user) return
-    const handleOnline = () => {
+    const handleSync = () => {
       syncQueue(user.id)
         .then(() => downloadUserData(user.id))
         .catch(console.error)
     }
-    window.addEventListener('online', handleOnline)
-    syncQueue(user.id)
-      .then(() => downloadUserData(user.id))
-      .catch(console.error)
+    window.addEventListener('online', handleSync)
+    handleSync()
+    const interval = setInterval(handleSync, 5 * 60 * 1000)
     return () => {
-      window.removeEventListener('online', handleOnline)
+      window.removeEventListener('online', handleSync)
+      clearInterval(interval)
     }
   }, [user])
 


### PR DESCRIPTION
## Summary
- refresh local data on every change via a `dataUpdated` event
- poll Supabase periodically and merge new data
- update pages to listen for data updates

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684712c899b48327a142582d7602d28f