### PR TITLE
Add offline data merge option

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ When you sign in from the Settings page the app will sync any queued changes to 
 Backups exported to JSON now include an `exportedAt` timestamp. When you import a backup while logged in, this timestamp is used to immediately sync the restored data with Supabase.
 
 Whenever data is downloaded from Supabase it is merged with your local storage using an `updatedAt` timestamp so that the newest version of every product, client and transaction is kept.
+If you created data before logging in, open Settings and use **Include offline data** to merge it with your account and sync.
 
 ---
 
@@ -146,7 +147,7 @@ interface Transaction {
 ## 🙋 FAQ
 
 **Q: Does this app send data anywhere?**
-A: No. All data stays in your browser via `localStorage`.
+A: No. All data stays in your browser via `localStorage`. Each account (including when not logged in) uses its own storage so your data never mixes with other users.
 
 **Q: Can I use it offline?**
 A: Yes! It’s a PWA — install it and it works offline like a native app.

--- a/src/components/pages/SettingsPageContent.tsx
+++ b/src/components/pages/SettingsPageContent.tsx
@@ -8,8 +8,10 @@ import { applyTheme, getStoredTheme, Theme } from '@/utils/theme';
 import { Settings as SettingsType, Currency, TravelUnit } from '@/types';
 import { getProducts } from '@/utils/productStorage';
 import { notifyDataUpdated } from '@/utils/dataUpdateEvent';
+import { storageKey } from '@/utils/userStorage'
 import { useSupabaseAuth } from '@/utils/useSupabaseAuth';
 import { syncQueue, downloadUserData } from '@/utils/syncSupabase';
+import { includeOfflineData } from '@/utils/includeOfflineData'
 import { supabase } from '@/utils/supabaseClient';
 import { localizeSupabaseMessage } from '@/utils/supabaseMessages';
 import { Card, CardContent } from '@/components/ui/card';
@@ -59,6 +61,7 @@ export default function SettingsPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [hasOfflineData, setHasOfflineData] = useState(false)
 
   useEffect(() => {
     const saved = getSettings();
@@ -67,6 +70,14 @@ export default function SettingsPage() {
     setSettings(updated);
     applyTheme(updated.theme);
   }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const hasData = ['vet_products_local', 'vet_clients_local', 'vet_transactions_local'].some(key =>
+      !!localStorage.getItem(key),
+    )
+    setHasOfflineData(hasData)
+  }, [user])
 
   const handleChange = <K extends keyof SettingsType>(field: K, value: SettingsType[K]) => {
     const updated = { ...settings, [field]: value };
@@ -82,8 +93,8 @@ export default function SettingsPage() {
       const travelName = itemTypeT('travel').toLowerCase();
       const idx = products.findIndex(p => p.name.toLowerCase() === travelName);
       if (idx !== -1) {
-        products[idx] = { ...products[idx], unit: value as TravelUnit };
-        localStorage.setItem('vet_products', JSON.stringify(products));
+        products[idx] = { ...products[idx], unit: value as TravelUnit }
+        localStorage.setItem(storageKey('vet_products'), JSON.stringify(products))
         notifyDataUpdated();
       }
     }
@@ -120,6 +131,15 @@ export default function SettingsPage() {
       toast.error(localizeSupabaseMessage(error.message, authT, 'deleteAccountError'));
     }
   };
+
+  const handleIncludeOffline = async () => {
+    const { data } = await supabase.auth.getUser()
+    const uid = data.user?.id
+    if (!uid) return
+    await includeOfflineData(uid)
+    toast.success(t('includeOfflineSuccess'))
+    setHasOfflineData(false)
+  }
 
   return (
     <div className='max-w-2xl mx-auto'>
@@ -243,6 +263,14 @@ export default function SettingsPage() {
 
           <div className='flex gap-3 flex-wrap pt-4'>
             <ImportButton onFinish={() => window.location.reload()} />
+            {user && hasOfflineData && (
+              <Button
+                onClick={handleIncludeOffline}
+                className='gap-2 bg-yellow-500 hover:bg-yellow-600 text-white dark:bg-yellow-600 dark:hover:bg-yellow-700'
+              >
+                {t('includeOffline')}
+              </Button>
+            )}
             <Button
               onClick={() => exportAllDataToJSON()}
               variant='default'

--- a/src/public/locales/en.json
+++ b/src/public/locales/en.json
@@ -159,6 +159,8 @@
     "distanceKm": "Kilometer",
     "distanceMi": "Mile",
     "export": "Export Data",
+    "includeOffline": "Include offline data",
+    "includeOfflineSuccess": "\u2705 Offline data added.",
     "loginTitle": "Login",
     "password": "Password",
     "login": "Log in",

--- a/src/public/locales/pl.json
+++ b/src/public/locales/pl.json
@@ -159,6 +159,8 @@
     "distanceKm": "Kilometr",
     "distanceMi": "Mila",
     "export": "Eksportuj dane",
+    "includeOffline": "Dołącz dane offline",
+    "includeOfflineSuccess": "\u2705 Dane offline dodane.",
     "loginTitle": "Logowanie",
     "password": "Hasło",
     "login": "Zaloguj",

--- a/src/utils/clientStorage.ts
+++ b/src/utils/clientStorage.ts
@@ -1,13 +1,15 @@
 import { Client } from '@/types';
-import { queueOperation } from './syncSupabase';
-import { notifyDataUpdated } from './dataUpdateEvent';
-import { getTransactions, deleteTransaction } from './transactionStorage';
+import { queueOperation } from './syncSupabase'
+import { notifyDataUpdated } from './dataUpdateEvent'
+import { getTransactions, deleteTransaction } from './transactionStorage'
+import { storageKey } from './userStorage'
 
-const STORAGE_KEY = 'vet_clients';
+const BASE_KEY = 'vet_clients'
+const STORAGE_KEY = () => storageKey(BASE_KEY)
 
 export function getClients(): Client[] {
   if (typeof window === 'undefined') return [];
-  const stored = localStorage.getItem(STORAGE_KEY);
+  const stored = localStorage.getItem(STORAGE_KEY())
   return stored ? JSON.parse(stored) : [];
 }
 
@@ -19,14 +21,14 @@ export function saveClient(client: Client) {
     index !== -1
       ? [...all.slice(0, index), clientToSave, ...all.slice(index + 1)]
       : [...all, clientToSave];
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+  localStorage.setItem(STORAGE_KEY(), JSON.stringify(updated))
   notifyDataUpdated();
   queueOperation({ type: 'upsert', table: 'clients', data: clientToSave });
 }
 
 export function deleteClient(id: string): void {
-  const clients = getClients().filter(c => c.id !== id);
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(clients));
+  const clients = getClients().filter(c => c.id !== id)
+  localStorage.setItem(STORAGE_KEY(), JSON.stringify(clients))
   notifyDataUpdated();
 
   const toDelete = getTransactions().filter(t => t.clientId === id);

--- a/src/utils/exportStorage.ts
+++ b/src/utils/exportStorage.ts
@@ -1,13 +1,14 @@
-import { saveAs } from 'file-saver';
-import pl from '@/public/locales/pl.json';
-import en from '@/public/locales/en.json';
+import { saveAs } from 'file-saver'
+import pl from '@/public/locales/pl.json'
+import en from '@/public/locales/en.json'
+import { storageKey } from './userStorage'
 
 export function exportAllDataToJSON() {
-  const settings = JSON.parse(localStorage.getItem('vet_settings') || '{}');
+  const settings = JSON.parse(localStorage.getItem(storageKey('vet_settings')) || '{}')
   const data = {
-    products: JSON.parse(localStorage.getItem('vet_products') || '[]'),
-    clients: JSON.parse(localStorage.getItem('vet_clients') || '[]'),
-    transactions: JSON.parse(localStorage.getItem('vet_transactions') || '[]'),
+    products: JSON.parse(localStorage.getItem(storageKey('vet_products')) || '[]'),
+    clients: JSON.parse(localStorage.getItem(storageKey('vet_clients')) || '[]'),
+    transactions: JSON.parse(localStorage.getItem(storageKey('vet_transactions')) || '[]'),
     exportedAt: new Date().toISOString(),
     settings,
   };

--- a/src/utils/importStorage.ts
+++ b/src/utils/importStorage.ts
@@ -1,9 +1,10 @@
 'use client';
 
 import { toast } from 'sonner';
-import { queueOperation, syncQueue } from './syncSupabase';
-import { supabase } from './supabaseClient';
-import { notifyDataUpdated } from './dataUpdateEvent';
+import { queueOperation, syncQueue } from './syncSupabase'
+import { supabase } from './supabaseClient'
+import { notifyDataUpdated } from './dataUpdateEvent'
+import { storageKey } from './userStorage'
 import type { Product, Client, Transaction } from '@/types';
 
 export function importAllDataFromJSON(
@@ -26,7 +27,7 @@ export function importAllDataFromJSON(
           ...p,
           updatedAt: p.updatedAt || new Date().toISOString(),
         }))
-        localStorage.setItem('vet_products', JSON.stringify(productsWithDates))
+        localStorage.setItem(storageKey('vet_products'), JSON.stringify(productsWithDates))
         notifyDataUpdated()
         productsWithDates.forEach(p =>
           queueOperation({ type: 'upsert', table: 'products', data: p })
@@ -37,7 +38,7 @@ export function importAllDataFromJSON(
           ...c,
           updatedAt: c.updatedAt || new Date().toISOString(),
         }))
-        localStorage.setItem('vet_clients', JSON.stringify(clientsWithDates))
+        localStorage.setItem(storageKey('vet_clients'), JSON.stringify(clientsWithDates))
         notifyDataUpdated()
         clientsWithDates.forEach(c =>
           queueOperation({ type: 'upsert', table: 'clients', data: c })
@@ -48,17 +49,17 @@ export function importAllDataFromJSON(
           ...t,
           updatedAt: t.updatedAt || new Date().toISOString(),
         }))
-        localStorage.setItem('vet_transactions', JSON.stringify(transactionsWithDates))
+        localStorage.setItem(storageKey('vet_transactions'), JSON.stringify(transactionsWithDates))
         notifyDataUpdated()
         transactionsWithDates.forEach(t =>
           queueOperation({ type: 'upsert', table: 'transactions', data: t })
         )
       }
       if (parsed.settings) {
-        localStorage.setItem('vet_settings', JSON.stringify(parsed.settings));
+        localStorage.setItem(storageKey('vet_settings'), JSON.stringify(parsed.settings))
       }
       if (parsed.exportedAt) {
-        localStorage.setItem('vet_last_import', parsed.exportedAt);
+        localStorage.setItem(storageKey('vet_last_import'), parsed.exportedAt)
       }
 
       supabase.auth.getUser().then(res => {

--- a/src/utils/includeOfflineData.ts
+++ b/src/utils/includeOfflineData.ts
@@ -1,0 +1,60 @@
+import { queueOperation, syncQueue } from './syncSupabase'
+import { notifyDataUpdated } from './dataUpdateEvent'
+import { storageKey } from './userStorage'
+import type { Product, Client, Transaction } from '@/types'
+
+interface Operation {
+  type: 'upsert' | 'delete'
+  table: 'products' | 'clients' | 'transactions'
+  data?: Product | Client | Transaction
+  id?: string
+}
+
+function mergeById<T extends { id: string; updatedAt?: string }>(
+  base: T[],
+  extra: T[],
+): T[] {
+  const map = new Map(base.map(i => [i.id, i]))
+  for (const item of extra) {
+    const existing = map.get(item.id)
+    if (!existing) {
+      map.set(item.id, item)
+      continue
+    }
+    const baseTime = existing.updatedAt ? new Date(existing.updatedAt).getTime() : 0
+    const extraTime = item.updatedAt ? new Date(item.updatedAt).getTime() : 0
+    if (extraTime > baseTime) map.set(item.id, item)
+  }
+  return Array.from(map.values())
+}
+
+export async function includeOfflineData(userId: string) {
+  if (typeof window === 'undefined') return
+
+  const localProducts = JSON.parse(localStorage.getItem('vet_products_local') || '[]') as Product[]
+  const localClients = JSON.parse(localStorage.getItem('vet_clients_local') || '[]') as Client[]
+  const localTransactions = JSON.parse(localStorage.getItem('vet_transactions_local') || '[]') as Transaction[]
+
+  const userProducts = JSON.parse(localStorage.getItem(storageKey('vet_products')) || '[]') as Product[]
+  const userClients = JSON.parse(localStorage.getItem(storageKey('vet_clients')) || '[]') as Client[]
+  const userTransactions = JSON.parse(localStorage.getItem(storageKey('vet_transactions')) || '[]') as Transaction[]
+
+  const mergedProducts = mergeById(userProducts, localProducts)
+  const mergedClients = mergeById(userClients, localClients)
+  const mergedTransactions = mergeById(userTransactions, localTransactions)
+
+  localStorage.setItem(storageKey('vet_products'), JSON.stringify(mergedProducts))
+  localStorage.setItem(storageKey('vet_clients'), JSON.stringify(mergedClients))
+  localStorage.setItem(storageKey('vet_transactions'), JSON.stringify(mergedTransactions))
+
+  const localQueue = JSON.parse(localStorage.getItem('vet_supabase_queue_local') || '[]') as Operation[]
+  localQueue.forEach(op => queueOperation(op))
+
+  localStorage.removeItem('vet_products_local')
+  localStorage.removeItem('vet_clients_local')
+  localStorage.removeItem('vet_transactions_local')
+  localStorage.removeItem('vet_supabase_queue_local')
+
+  notifyDataUpdated()
+  await syncQueue(userId)
+}

--- a/src/utils/productStorage.ts
+++ b/src/utils/productStorage.ts
@@ -1,12 +1,14 @@
-import { Product } from '@/types';
-import { queueOperation } from './syncSupabase';
-import { notifyDataUpdated } from './dataUpdateEvent';
+import { Product } from '@/types'
+import { queueOperation } from './syncSupabase'
+import { notifyDataUpdated } from './dataUpdateEvent'
+import { storageKey } from './userStorage'
 
-const STORAGE_KEY = 'vet_products';
+const BASE_KEY = 'vet_products'
+const STORAGE_KEY = () => storageKey(BASE_KEY)
 
 export function getProducts(): Product[] {
   try {
-    return JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]') as Product[];
+    return JSON.parse(localStorage.getItem(STORAGE_KEY()) || '[]') as Product[]
   } catch {
     return [];
   }
@@ -20,14 +22,14 @@ export function saveProduct(product: Product) {
     index !== -1
       ? [...all.slice(0, index), productToSave, ...all.slice(index + 1)]
       : [...all, productToSave];
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+  localStorage.setItem(STORAGE_KEY(), JSON.stringify(updated))
   notifyDataUpdated();
   queueOperation({ type: 'upsert', table: 'products', data: productToSave });
 }
 
 export function deleteProduct(id: string): void {
-  const products = getProducts().filter(p => p.id !== id);
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(products));
+  const products = getProducts().filter(p => p.id !== id)
+  localStorage.setItem(STORAGE_KEY(), JSON.stringify(products))
   notifyDataUpdated();
   queueOperation({ type: 'delete', table: 'products', id });
 }

--- a/src/utils/settingsStorage.ts
+++ b/src/utils/settingsStorage.ts
@@ -1,6 +1,8 @@
-import { Settings } from '@/types';
+import { Settings } from '@/types'
+import { storageKey } from './userStorage'
 
-const STORAGE_KEY = 'vet_settings';
+const BASE_KEY = 'vet_settings'
+const STORAGE_KEY = () => storageKey(BASE_KEY)
 
 const defaultSettings: Settings = {
   currency: 'zł',
@@ -11,14 +13,14 @@ const defaultSettings: Settings = {
 
 export function getSettings(): Settings {
   if (typeof window === 'undefined') return defaultSettings;
-  const stored = localStorage.getItem(STORAGE_KEY);
-  return stored ? { ...defaultSettings, ...JSON.parse(stored) } : defaultSettings;
+  const stored = localStorage.getItem(STORAGE_KEY())
+  return stored ? { ...defaultSettings, ...JSON.parse(stored) } : defaultSettings
 }
 
 export function saveSettings(data: Settings) {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  localStorage.setItem(STORAGE_KEY(), JSON.stringify(data))
 }
 
 export function resetSettings() {
-  localStorage.removeItem(STORAGE_KEY);
+  localStorage.removeItem(STORAGE_KEY())
 }

--- a/src/utils/syncSupabase.ts
+++ b/src/utils/syncSupabase.ts
@@ -3,6 +3,7 @@
 import { supabase } from './supabaseClient'
 import { notifyDataUpdated } from './dataUpdateEvent'
 import { Client, Product, Transaction } from '@/types'
+import { storageKey } from './userStorage'
 
 function snakeCaseKeys<T extends Record<string, unknown>>(obj: T): Record<string, unknown> {
   return Object.fromEntries(
@@ -40,18 +41,19 @@ interface Operation {
   id?: string
 }
 
-const QUEUE_KEY = 'vet_supabase_queue'
+const QUEUE_KEY_BASE = 'vet_supabase_queue'
+const QUEUE_KEY = () => storageKey(QUEUE_KEY_BASE)
 
 function getQueue(): Operation[] {
   try {
-    return JSON.parse(localStorage.getItem(QUEUE_KEY) || '[]') as Operation[]
+    return JSON.parse(localStorage.getItem(QUEUE_KEY()) || '[]') as Operation[]
   } catch {
     return []
   }
 }
 
 function saveQueue(queue: Operation[]) {
-  localStorage.setItem(QUEUE_KEY, JSON.stringify(queue))
+  localStorage.setItem(QUEUE_KEY(), JSON.stringify(queue))
 }
 
 export async function queueOperation(op: Operation) {
@@ -179,21 +181,21 @@ export async function downloadUserData(userId: string) {
     })
 
     const mergedProducts = mergeById(
-      JSON.parse(localStorage.getItem('vet_products') || '[]'),
+      JSON.parse(localStorage.getItem(storageKey('vet_products')) || '[]'),
       products,
     )
     const mergedClients = mergeById(
-      JSON.parse(localStorage.getItem('vet_clients') || '[]'),
+      JSON.parse(localStorage.getItem(storageKey('vet_clients')) || '[]'),
       clients,
     )
     const mergedTransactions = mergeById(
-      JSON.parse(localStorage.getItem('vet_transactions') || '[]'),
+      JSON.parse(localStorage.getItem(storageKey('vet_transactions')) || '[]'),
       transactions,
     )
 
-    localStorage.setItem('vet_products', JSON.stringify(mergedProducts))
-    localStorage.setItem('vet_clients', JSON.stringify(mergedClients))
-    localStorage.setItem('vet_transactions', JSON.stringify(mergedTransactions))
+    localStorage.setItem(storageKey('vet_products'), JSON.stringify(mergedProducts))
+    localStorage.setItem(storageKey('vet_clients'), JSON.stringify(mergedClients))
+    localStorage.setItem(storageKey('vet_transactions'), JSON.stringify(mergedTransactions))
     notifyDataUpdated()
   } catch (e) {
     console.error('Supabase download error', e)

--- a/src/utils/transactionStorage.ts
+++ b/src/utils/transactionStorage.ts
@@ -1,13 +1,15 @@
-import { Transaction } from '@/types';
-import { queueOperation } from './syncSupabase';
-import { notifyDataUpdated } from './dataUpdateEvent';
+import { Transaction } from '@/types'
+import { queueOperation } from './syncSupabase'
+import { notifyDataUpdated } from './dataUpdateEvent'
 import { v4 as uuid } from 'uuid';
+import { storageKey } from './userStorage'
 
-const STORAGE_KEY = 'vet_transactions';
+const BASE_KEY = 'vet_transactions'
+const STORAGE_KEY = () => storageKey(BASE_KEY)
 
 export function getTransactions(): Transaction[] {
   if (typeof window === 'undefined') return [];
-  const stored = localStorage.getItem(STORAGE_KEY);
+  const stored = localStorage.getItem(STORAGE_KEY())
   return stored ? JSON.parse(stored) : [];
 }
 
@@ -28,7 +30,7 @@ export function saveTransaction(tx: Transaction): Transaction {
     all.push(transactionToSave);
   }
 
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(all));
+  localStorage.setItem(STORAGE_KEY(), JSON.stringify(all))
   notifyDataUpdated();
   if (transactionToSave.clientId) {
     queueOperation({
@@ -45,8 +47,8 @@ export function updateTransaction(tx: Transaction): Transaction {
 }
 
 export function deleteTransaction(id: string): void {
-  const filtered = getTransactions().filter((t) => t.id !== id);
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(filtered));
+  const filtered = getTransactions().filter((t) => t.id !== id)
+  localStorage.setItem(STORAGE_KEY(), JSON.stringify(filtered))
   notifyDataUpdated();
   queueOperation({ type: 'delete', table: 'transactions', id });
 }

--- a/src/utils/useSupabaseAuth.ts
+++ b/src/utils/useSupabaseAuth.ts
@@ -2,6 +2,7 @@
 import { useEffect, useState } from 'react'
 import { supabase } from './supabaseClient'
 import { syncQueue, downloadUserData } from './syncSupabase'
+import { setCurrentUserId } from './userStorage'
 import type { User } from '@supabase/supabase-js'
 
 export function useSupabaseAuth() {
@@ -16,6 +17,11 @@ export function useSupabaseAuth() {
       data.subscription.unsubscribe()
     }
   }, [])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    setCurrentUserId(user?.id ?? null)
+  }, [user])
 
   useEffect(() => {
     if (!user) return

--- a/src/utils/userStorage.ts
+++ b/src/utils/userStorage.ts
@@ -1,0 +1,16 @@
+export const CURRENT_USER_KEY = 'vet_current_user'
+
+export function getCurrentUserId(): string {
+  if (typeof window === 'undefined') return 'local'
+  return localStorage.getItem(CURRENT_USER_KEY) || 'local'
+}
+
+export function setCurrentUserId(id: string | null): void {
+  if (typeof window === 'undefined') return
+  if (id) localStorage.setItem(CURRENT_USER_KEY, id)
+  else localStorage.setItem(CURRENT_USER_KEY, 'local')
+}
+
+export function storageKey(base: string): string {
+  return `${base}_${getCurrentUserId()}`
+}


### PR DESCRIPTION
## Summary
- create helper to merge offline data when logging in
- add button in Settings to include local data
- translate new labels
- mention offline data option in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684716e6d2e88327afc8cb5878efe6c4