### PR TITLE
Ensure product type persists

### DIFF
--- a/src/components/ProductForm.tsx
+++ b/src/components/ProductForm.tsx
@@ -42,7 +42,7 @@ export default function ProductForm({ onAdd }: { onAdd: () => void }) {
     if (!product) return;
     setName(product.name);
     setPrice(product.pricePerUnit.toString());
-    setType(product.type);
+    setType(product.type || 'product');
 
     if (predefinedUnits.includes(product.unit)) {
       setUnit(product.unit as Unit);
@@ -67,7 +67,7 @@ export default function ProductForm({ onAdd }: { onAdd: () => void }) {
       name,
       unit: finalUnit,
       pricePerUnit: Math.round(parsedPrice * 100) / 100,
-      type,
+      type: type || 'product',
     });
 
     onAdd();

--- a/src/utils/importStorage.ts
+++ b/src/utils/importStorage.ts
@@ -5,7 +5,8 @@ import { queueOperation, syncQueue } from './syncSupabase'
 import { supabase } from './supabaseClient'
 import { notifyDataUpdated } from './dataUpdateEvent'
 import { storageKey } from './userStorage'
-import type { Product, Client, Transaction } from '@/types';
+import type { Product, Client, Transaction } from '@/types'
+import { normalizeProduct } from './productStorage'
 
 export function importAllDataFromJSON(
   file: File,
@@ -23,10 +24,12 @@ export function importAllDataFromJSON(
       const parsed = JSON.parse(reader.result as string);
 
       if (parsed.products) {
-        const productsWithDates = (parsed.products as Product[]).map(p => ({
-          ...p,
-          updatedAt: p.updatedAt || new Date().toISOString(),
-        }))
+        const productsWithDates = (parsed.products as Product[]).map(p =>
+          normalizeProduct({
+            ...p,
+            updatedAt: p.updatedAt || new Date().toISOString(),
+          }),
+        )
         localStorage.setItem(storageKey('vet_products'), JSON.stringify(productsWithDates))
         notifyDataUpdated()
         productsWithDates.forEach(p =>

--- a/src/utils/includeOfflineData.ts
+++ b/src/utils/includeOfflineData.ts
@@ -2,6 +2,7 @@ import { queueOperation, syncQueue } from './syncSupabase'
 import { notifyDataUpdated } from './dataUpdateEvent'
 import { storageKey } from './userStorage'
 import type { Product, Client, Transaction } from '@/types'
+import { normalizeProduct } from './productStorage'
 
 interface Operation {
   type: 'upsert' | 'delete'
@@ -39,7 +40,7 @@ export async function includeOfflineData(userId: string) {
   const userClients = JSON.parse(localStorage.getItem(storageKey('vet_clients')) || '[]') as Client[]
   const userTransactions = JSON.parse(localStorage.getItem(storageKey('vet_transactions')) || '[]') as Transaction[]
 
-  const mergedProducts = mergeById(userProducts, localProducts)
+  const mergedProducts = mergeById(userProducts, localProducts).map(normalizeProduct)
   const mergedClients = mergeById(userClients, localClients)
   const mergedTransactions = mergeById(userTransactions, localTransactions)
 

--- a/src/utils/syncSupabase.ts
+++ b/src/utils/syncSupabase.ts
@@ -4,6 +4,7 @@ import { supabase } from './supabaseClient'
 import { notifyDataUpdated } from './dataUpdateEvent'
 import { Client, Product, Transaction } from '@/types'
 import { storageKey } from './userStorage'
+import { normalizeProduct } from './productStorage'
 
 function snakeCaseKeys<T extends Record<string, unknown>>(obj: T): Record<string, unknown> {
   return Object.fromEntries(
@@ -169,7 +170,10 @@ export async function downloadUserData(userId: string) {
 
     const products = (productsRes.data || []).map(r => {
       const { updated_at, ...rest } = r as Record<string, unknown>
-      return { ...(camelCaseKeys(rest) as Product), updatedAt: updated_at as string }
+      return normalizeProduct({
+        ...(camelCaseKeys(rest) as Product),
+        updatedAt: updated_at as string,
+      })
     })
     const clients = (clientsRes.data || []).map(r => {
       const { updated_at, ...rest } = r as Record<string, unknown>
@@ -183,7 +187,7 @@ export async function downloadUserData(userId: string) {
     const mergedProducts = mergeById(
       JSON.parse(localStorage.getItem(storageKey('vet_products')) || '[]'),
       products,
-    )
+    ).map(normalizeProduct)
     const mergedClients = mergeById(
       JSON.parse(localStorage.getItem(storageKey('vet_clients')) || '[]'),
       clients,


### PR DESCRIPTION
## Summary
- Normalize product objects to default to `product` when type missing
- Save selected product type reliably in form
- Sanitize imports and sync operations to enforce product type

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be9b483d8c8327abd267d57b81fdf3