### PR TITLE
feat: enhance date and time inputs in transaction form

### DIFF
--- a/src/components/TransactionForm.tsx
+++ b/src/components/TransactionForm.tsx
@@ -10,6 +10,8 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
+import { DatePicker } from '@/components/ui/date-picker';
+import { TimePicker } from '@/components/ui/time-picker';
 import { useDebouncedCallback } from 'use-debounce';
 import { ComboboxGeneric } from '@/components/ComboboxGeneric';
 import { Trash } from 'lucide-react';
@@ -284,22 +286,20 @@ export default function TransactionForm({
         <div className='flex flex-col sm:flex-row gap-4'>
           <div className='flex-1'>
             <Label className='py-2'>{t('date')}</Label>
-            <Input
-              type='date'
+            <DatePicker
               value={transactionDate}
-              onChange={e => setTransactionDate(e.target.value)}
+              onChange={setTransactionDate}
+              placeholder={t('selectDate')}
               disabled={readOnly}
-              className={`${readOnly ? 'bg-transparent text-foreground opacity-100 border-none' : ''}`}
             />
           </div>
           <div className='flex-1'>
             <Label className='py-2'>{t('time')}</Label>
-            <Input
-              type='time'
+            <TimePicker
               value={transactionTime}
-              onChange={e => setTransactionTime(e.target.value)}
+              onChange={setTransactionTime}
+              placeholder={t('selectTime')}
               disabled={readOnly}
-              className={`${readOnly ? 'bg-transparent text-foreground opacity-100 border-none' : ''}`}
             />
           </div>
         </div>

--- a/src/components/ui/date-picker.tsx
+++ b/src/components/ui/date-picker.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { format } from "date-fns";
+import { Calendar as CalendarIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+interface DatePickerProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+export function DatePicker({ value, onChange, placeholder, disabled }: DatePickerProps) {
+  const date = value ? new Date(value) : undefined;
+
+  if (disabled) {
+    return (
+      <div className="h-9 px-3 py-2 flex items-center text-foreground">
+        {date ? format(date, "PPP") : placeholder}
+      </div>
+    );
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          className={cn(
+            "w-full justify-start text-left font-normal",
+            !date && "text-muted-foreground"
+          )}
+        >
+          <CalendarIcon className="mr-2 h-4 w-4" />
+          {date ? format(date, "PPP") : <span>{placeholder}</span>}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-0">
+        <Calendar
+          mode="single"
+          selected={date}
+          onSelect={d => d && onChange(format(d, "yyyy-MM-dd"))}
+          initialFocus
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/ui/time-picker.tsx
+++ b/src/components/ui/time-picker.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { Clock } from "lucide-react";
+import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from "@/components/ui/select";
+
+interface TimePickerProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+const times = Array.from({ length: 96 }, (_, i) => {
+  const h = String(Math.floor(i / 4)).padStart(2, "0");
+  const m = String((i % 4) * 15).padStart(2, "0");
+  return `${h}:${m}`;
+});
+
+export function TimePicker({ value, onChange, placeholder, disabled }: TimePickerProps) {
+  if (disabled) {
+    return (
+      <div className="h-9 px-3 py-2 flex items-center text-foreground">
+        {value || placeholder}
+      </div>
+    );
+  }
+
+  return (
+    <Select value={value || undefined} onValueChange={onChange} disabled={disabled}>
+      <SelectTrigger className="w-full">
+        <Clock className="mr-2 h-4 w-4" />
+        <SelectValue placeholder={placeholder} />
+      </SelectTrigger>
+      <SelectContent>
+        {times.map(t => (
+          <SelectItem key={t} value={t}>
+            {t}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/public/locales/en.json
+++ b/src/public/locales/en.json
@@ -237,7 +237,9 @@
     "travelNote": "⚠️ Enter round-trip kilometers (both ways)",
     "priceChanged": "⚠️ Product price has changed (currently: {price} zł)",
     "date": "Date",
-    "time": "Time"
+    "time": "Time",
+    "selectDate": "Select date",
+    "selectTime": "Select time"
   },
   "clientModal": {
     "title": "Add client"

--- a/src/public/locales/pl.json
+++ b/src/public/locales/pl.json
@@ -237,7 +237,9 @@
     "travelNote": "⚠️ Podaj liczbę kilometrów tam i z powrotem (łącznie w dwie strony)",
     "priceChanged": "⚠️ Cena produktu uległa zmianie (obecnie: {price} {currency})",
     "date": "Data",
-    "time": "Godzina"
+    "time": "Godzina",
+    "selectDate": "Wybierz datę",
+    "selectTime": "Wybierz godzinę"
   },
   "clientModal": {
     "title": "Dodaj klienta"


### PR DESCRIPTION
## Summary
- replace raw date and time inputs with custom DatePicker and TimePicker widgets in the transaction form
- add reusable date and time picker components
- provide i18n strings for date and time placeholders

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bec803cecc832780c380706f4e93ae