### PR TITLE
feat: localise transaction date and time

### DIFF
--- a/src/components/TransactionForm.tsx
+++ b/src/components/TransactionForm.tsx
@@ -56,6 +56,10 @@ export default function TransactionForm({
     return new Date(`${date}T${timePart}`).toISOString();
   };
 
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  const formatDate = (d: Date) => `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+  const formatTime = (d: Date) => `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+
   useEffect(() => {
     setLocalQuantities(items.map(i => i.quantity.toString()));
   }, [items]);
@@ -98,13 +102,13 @@ export default function TransactionForm({
       setId(editingTransaction.id);
       setDescription(editingTransaction.description || '');
       const d = new Date(editingTransaction.date);
-      setTransactionDate(d.toISOString().slice(0, 10));
-      setTransactionTime(d.toISOString().slice(11, 16));
+      setTransactionDate(formatDate(d));
+      setTransactionTime(formatTime(d));
     }
     if (!editingTransaction) {
       const now = new Date();
-      setTransactionDate(now.toISOString().slice(0, 10));
-      setTransactionTime(now.toISOString().slice(11, 16));
+      setTransactionDate(formatDate(now));
+      setTransactionTime(formatTime(now));
     }
   }, [editingTransaction]);
 

--- a/src/components/ui/date-picker.tsx
+++ b/src/components/ui/date-picker.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { format } from "date-fns";
+import { enUS, pl } from "date-fns/locale";
 import { Calendar as CalendarIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
+import { getSettings } from "@/utils/settingsStorage";
 
 interface DatePickerProps {
   value: string;
@@ -15,12 +17,14 @@ interface DatePickerProps {
 }
 
 export function DatePicker({ value, onChange, placeholder, disabled }: DatePickerProps) {
+  const { language } = getSettings();
+  const locale = language === "pl" ? pl : enUS;
   const date = value ? new Date(value) : undefined;
 
   if (disabled) {
     return (
       <div className="h-9 px-3 py-2 flex items-center text-foreground">
-        {date ? format(date, "PPP") : placeholder}
+        {date ? format(date, "PPP", { locale }) : placeholder}
       </div>
     );
   }
@@ -36,7 +40,7 @@ export function DatePicker({ value, onChange, placeholder, disabled }: DatePicke
           )}
         >
           <CalendarIcon className="mr-2 h-4 w-4" />
-          {date ? format(date, "PPP") : <span>{placeholder}</span>}
+          {date ? format(date, "PPP", { locale }) : <span>{placeholder}</span>}
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-auto p-0">
@@ -45,6 +49,7 @@ export function DatePicker({ value, onChange, placeholder, disabled }: DatePicke
           selected={date}
           onSelect={d => d && onChange(format(d, "yyyy-MM-dd"))}
           initialFocus
+          locale={locale}
         />
       </PopoverContent>
     </Popover>

--- a/src/components/ui/time-picker.tsx
+++ b/src/components/ui/time-picker.tsx
@@ -1,7 +1,15 @@
 "use client";
 
 import { Clock } from "lucide-react";
-import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from "@/components/ui/select";
+import {
+  Select,
+  SelectTrigger,
+  SelectContent,
+  SelectItem,
+  SelectValue,
+} from "@/components/ui/select";
+import { useMemo } from "react";
+import { getSettings } from "@/utils/settingsStorage";
 
 interface TimePickerProps {
   value: string;
@@ -10,17 +18,29 @@ interface TimePickerProps {
   disabled?: boolean;
 }
 
-const times = Array.from({ length: 96 }, (_, i) => {
-  const h = String(Math.floor(i / 4)).padStart(2, "0");
-  const m = String((i % 4) * 15).padStart(2, "0");
-  return `${h}:${m}`;
-});
+const buildBaseTimes = () =>
+  Array.from({ length: 96 }, (_, i) => {
+    const h = String(Math.floor(i / 4)).padStart(2, "0");
+    const m = String((i % 4) * 15).padStart(2, "0");
+    return `${h}:${m}`;
+  });
 
 export function TimePicker({ value, onChange, placeholder, disabled }: TimePickerProps) {
+  const { language } = getSettings();
+  const formatter = useMemo(
+    () => new Intl.DateTimeFormat(language, { hour: "numeric", minute: "numeric" }),
+    [language]
+  );
+  const baseTimes = useMemo(buildBaseTimes, []);
+  const times = useMemo(() => {
+    return value && !baseTimes.includes(value) ? [value, ...baseTimes] : baseTimes;
+  }, [value, baseTimes]);
+  const formatTime = (t: string) => formatter.format(new Date(`1970-01-01T${t}`));
+
   if (disabled) {
     return (
       <div className="h-9 px-3 py-2 flex items-center text-foreground">
-        {value || placeholder}
+        {value ? formatTime(value) : placeholder}
       </div>
     );
   }
@@ -34,7 +54,7 @@ export function TimePicker({ value, onChange, placeholder, disabled }: TimePicke
       <SelectContent>
         {times.map(t => (
           <SelectItem key={t} value={t}>
-            {t}
+            {formatTime(t)}
           </SelectItem>
         ))}
       </SelectContent>


### PR DESCRIPTION
## Summary
- localise date and time pickers based on saved language
- prefill transaction form with existing date and time

## Testing
- `node node_modules/jest/bin/jest.js`
- `node node_modules/next/dist/bin/next lint` *(fails: Cannot find module '../server/require-hook')*


------
https://chatgpt.com/codex/tasks/task_e_68becf2fef5c832798b486b65b8c9f03