### PR TITLE
feat: add range export and travel report

### DIFF
--- a/src/app/transactions/travel-report/page.tsx
+++ b/src/app/transactions/travel-report/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import PageWrapper from '@/components/PageWrapper';
+import TravelReportPageContent from '@/components/pages/TravelReportPageContent';
+
+export default function TravelReportPage() {
+  return (
+    <PageWrapper>
+      <TravelReportPageContent />
+    </PageWrapper>
+  );
+}

--- a/src/components/pages/TransactionsPageContent.tsx
+++ b/src/components/pages/TransactionsPageContent.tsx
@@ -1,17 +1,50 @@
 'use client';
 
-import { Suspense } from 'react';
+import { Suspense, useState } from 'react';
 import useDataUpdate from '@/utils/useDataUpdate';
 import Link from 'next/link';
-import { PlusCircle, ReceiptText } from 'lucide-react';
+import { PlusCircle, ReceiptText, FileDown, MapPin } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import TransactionList from '@/components/TransactionList';
 import { useTranslations } from 'next-intl';
+import { DatePicker } from '@/components/ui/date-picker';
+import { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { handleExportRange } from '@/utils/pdfExport';
+import { getTransactions } from '@/utils/transactionStorage';
+import dayjs from 'dayjs';
+import { useRouter } from 'next/navigation';
 
 export default function TransactionsPage() {
   const refresh = useDataUpdate();
   const t = useTranslations('transactions');
+  const pdfT = useTranslations('pdfLabels');
+  const router = useRouter();
+  const [expFrom, setExpFrom] = useState('');
+  const [expTo, setExpTo] = useState('');
+  const [repFrom, setRepFrom] = useState('');
+  const [repTo, setRepTo] = useState('');
+
+  const exportLabels = {
+    header: pdfT('header'),
+    clientLabel: pdfT('clientLabel'),
+    addressLabel: pdfT('addressLabel'),
+    phoneLabel: pdfT('phoneLabel'),
+    notFound: pdfT('notFound'),
+    travel: pdfT('travel'),
+    items: pdfT('items'),
+    products: pdfT('products'),
+    services: pdfT('services'),
+    quantity: pdfT('quantity'),
+    unit: pdfT('unit'),
+    priceUnit: pdfT('priceUnit'),
+    value: pdfT('value'),
+    subtotal: pdfT('subtotal'),
+    discount: pdfT('discount'),
+    fee: pdfT('fee'),
+    total: pdfT('total'),
+    description: pdfT('description'),
+  };
 
   return (
     <Suspense fallback={<div>{t('loading')}</div>}>
@@ -23,13 +56,66 @@ export default function TransactionsPage() {
                 <ReceiptText className='w-8 h-8 text-green-600 dark:text-green-300' />
                 {t('title')}
               </h1>
-
-              <Link href='/transactions/new'>
-                <Button variant='default' className='flex items-center gap-2'>
-                  <PlusCircle className='w-4 h-4' />
-                  {t('addButton')}
-                </Button>
-              </Link>
+              <div className='flex items-center gap-2'>
+                <Dialog>
+                  <DialogTrigger asChild>
+                    <Button variant='outline' className='flex items-center gap-2'>
+                      <FileDown className='w-4 h-4' />
+                      {t('exportRange')}
+                    </Button>
+                  </DialogTrigger>
+                  <DialogContent>
+                    <DialogHeader>
+                      <DialogTitle>{t('exportRange')}</DialogTitle>
+                    </DialogHeader>
+                    <div className='flex flex-col gap-4 py-2'>
+                      <DatePicker value={expFrom} onChange={setExpFrom} placeholder={t('from')} />
+                      <DatePicker value={expTo} onChange={setExpTo} placeholder={t('to')} />
+                    </div>
+                    <DialogFooter>
+                      <Button onClick={() => {
+                        const txs = getTransactions().filter(tx => {
+                          const d = dayjs(tx.date);
+                          return (!expFrom || d.isAfter(dayjs(expFrom).subtract(1, 'day')))
+                            && (!expTo || d.isBefore(dayjs(expTo).add(1, 'day')));
+                        }).sort((a, b) => a.date.localeCompare(b.date));
+                        handleExportRange(txs, exportLabels, expFrom || 'start', expTo || 'end');
+                      }}>{t('generate')}</Button>
+                    </DialogFooter>
+                  </DialogContent>
+                </Dialog>
+                <Dialog>
+                  <DialogTrigger asChild>
+                    <Button variant='outline' className='flex items-center gap-2'>
+                      <MapPin className='w-4 h-4' />
+                      {t('travelReport')}
+                    </Button>
+                  </DialogTrigger>
+                  <DialogContent>
+                    <DialogHeader>
+                      <DialogTitle>{t('travelReport')}</DialogTitle>
+                    </DialogHeader>
+                    <div className='flex flex-col gap-4 py-2'>
+                      <DatePicker value={repFrom} onChange={setRepFrom} placeholder={t('from')} />
+                      <DatePicker value={repTo} onChange={setRepTo} placeholder={t('to')} />
+                    </div>
+                    <DialogFooter>
+                      <Button onClick={() => {
+                        const params = new URLSearchParams();
+                        if (repFrom) params.set('from', repFrom);
+                        if (repTo) params.set('to', repTo);
+                        router.push(`/transactions/travel-report?${params.toString()}`);
+                      }}>{t('generate')}</Button>
+                    </DialogFooter>
+                  </DialogContent>
+                </Dialog>
+                <Link href='/transactions/new'>
+                  <Button variant='default' className='flex items-center gap-2'>
+                    <PlusCircle className='w-4 h-4' />
+                    {t('addButton')}
+                  </Button>
+                </Link>
+              </div>
             </div>
 
             <TransactionList refresh={refresh} />

--- a/src/components/pages/TravelReportPageContent.tsx
+++ b/src/components/pages/TravelReportPageContent.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import dayjs from 'dayjs';
+import { useTranslations } from 'next-intl';
+import { Card, CardContent } from '@/components/ui/card';
+import { Table, TableHeader, TableHead, TableRow, TableBody, TableCell } from '@/components/ui/table';
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip } from 'recharts';
+import { getTransactions } from '@/utils/transactionStorage';
+import { getProducts } from '@/utils/productStorage';
+import { getClients } from '@/utils/clientStorage';
+
+interface TravelRow {
+  date: string;
+  client: string;
+  km: number;
+  value: number;
+}
+
+export default function TravelReportPageContent() {
+  const t = useTranslations('travelReport');
+  const listT = useTranslations('transactionsList');
+  const itemTypeT = useTranslations('itemType');
+  const params = useSearchParams();
+  const from = params.get('from');
+  const to = params.get('to');
+  const [rows, setRows] = useState<TravelRow[]>([]);
+
+  useEffect(() => {
+    const txs = getTransactions();
+    const products = getProducts();
+    const clients = getClients();
+    const filtered = txs.filter(tx => {
+      const d = dayjs(tx.date);
+      return (
+        (!from || d.isAfter(dayjs(from).subtract(1, 'day')))
+        && (!to || d.isBefore(dayjs(to).add(1, 'day')))
+      );
+    });
+    const data: TravelRow[] = [];
+    filtered.forEach(tx => {
+      const clientName = clients.find(c => c.id === tx.clientId)?.name || listT('unknownClient');
+      tx.items.forEach(item => {
+        const prod = products.find(p => p.id === item.productId);
+        if (prod && prod.name.toLowerCase() === itemTypeT('travel').toLowerCase()) {
+          const value = item.quantity * prod.pricePerUnit;
+          data.push({
+            date: dayjs(tx.date).format('YYYY-MM-DD'),
+            client: clientName,
+            km: item.quantity,
+            value,
+          });
+        }
+      });
+    });
+    setRows(data);
+  }, [from, to, listT, itemTypeT]);
+
+  const totalKm = rows.reduce((sum, r) => sum + r.km, 0);
+  const totalValue = rows.reduce((sum, r) => sum + r.value, 0);
+
+  const chartData = Object.values(
+    rows.reduce((acc, r) => {
+      if (!acc[r.date]) acc[r.date] = { date: r.date, km: 0 };
+      acc[r.date].km += r.km;
+      return acc;
+    }, {} as Record<string, { date: string; km: number }>)
+  );
+
+  return (
+    <div className='max-w-4xl mx-auto'>
+      <Card className='rounded-3xl border border-gray-200 dark:border-white/10 bg-gradient-to-tr from-indigo-200/30 via-sky-100/20 to-white/30 dark:from-indigo-500/30 dark:via-sky-500/10 dark:to-slate-900/20 shadow-2xl p-4'>
+        <CardContent className='p-2 space-y-6'>
+          <h1 className='text-3xl font-bold'>{t('title')}</h1>
+          <div className='flex gap-4'>
+            <span>{t('totalDistance')}: {totalKm}</span>
+            <span>{t('totalValue')}: {totalValue.toFixed(2)}</span>
+          </div>
+          <ResponsiveContainer width='100%' height={300}>
+            <BarChart data={chartData}>
+              <XAxis dataKey='date' />
+              <YAxis />
+              <Tooltip />
+              <Bar dataKey='km' fill='#3b82f6' />
+            </BarChart>
+          </ResponsiveContainer>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>{t('date')}</TableHead>
+                <TableHead>{t('client')}</TableHead>
+                <TableHead>{t('distance')}</TableHead>
+                <TableHead>{t('value')}</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={4} className='text-center'>{t('noData')}</TableCell>
+                </TableRow>
+              ) : (
+                rows.map((r, idx) => (
+                  <TableRow key={idx}>
+                    <TableCell>{r.date}</TableCell>
+                    <TableCell>{r.client}</TableCell>
+                    <TableCell>{r.km}</TableCell>
+                    <TableCell>{r.value.toFixed(2)}</TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/public/locales/en.json
+++ b/src/public/locales/en.json
@@ -87,7 +87,12 @@
   "transactions": {
     "title": "Transactions",
     "addButton": "Add",
-    "loading": "Loading..."
+    "loading": "Loading...",
+    "exportRange": "Export PDF",
+    "travelReport": "Travel report",
+    "from": "From",
+    "to": "To",
+    "generate": "Generate"
   },
   "transactionNew": {
     "title": "New Transaction",
@@ -207,6 +212,16 @@
     "deleteMessage": "Are you sure you want to delete the transaction for {client} on {date}?",
     "cancel": "Cancel",
     "delete": "Delete"
+  },
+  "travelReport": {
+    "title": "Travel report",
+    "totalDistance": "Total distance",
+    "totalValue": "Total value",
+    "date": "Date",
+    "client": "Client",
+    "distance": "Distance",
+    "value": "Value",
+    "noData": "No data."
   },
   "transactionForm": {
     "title": "Transaction",

--- a/src/public/locales/pl.json
+++ b/src/public/locales/pl.json
@@ -87,7 +87,12 @@
   "transactions": {
     "title": "Rozliczenia",
     "addButton": "Dodaj",
-    "loading": "Wczytywanie..."
+    "loading": "Wczytywanie...",
+    "exportRange": "Eksportuj PDF",
+    "travelReport": "Raport dojazdów",
+    "from": "Od",
+    "to": "Do",
+    "generate": "Generuj"
   },
   "transactionNew": {
     "title": "Nowe rozliczenie",
@@ -207,6 +212,16 @@
     "deleteMessage": "Czy na pewno chcesz usunąć rozliczenie dla {client} z dnia {date}?",
     "cancel": "Anuluj",
     "delete": "Usuń"
+  },
+  "travelReport": {
+    "title": "Raport dojazdów",
+    "totalDistance": "Łączna odległość",
+    "totalValue": "Łączna wartość",
+    "date": "Data",
+    "client": "Klient",
+    "distance": "Dystans",
+    "value": "Wartość",
+    "noData": "Brak danych."
   },
   "transactionForm": {
     "title": "Rozliczenie",


### PR DESCRIPTION
## Summary
- add date range export for transactions
- create travel report page with totals and chart
- support multi-transaction PDF export

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bed1940c808327be810987f65e9481