### PR TITLE
Refactor travel report page to use Suspense

### DIFF
--- a/src/app/transactions/travel-report/page.tsx
+++ b/src/app/transactions/travel-report/page.tsx
@@ -1,12 +1,18 @@
 'use client';
 
+import { Suspense } from 'react';
+import { useTranslations } from 'next-intl';
 import PageWrapper from '@/components/PageWrapper';
 import TravelReportPageContent from '@/components/pages/TravelReportPageContent';
 
 export default function TravelReportPage() {
+  const t = useTranslations('travelReport');
+
   return (
     <PageWrapper>
-      <TravelReportPageContent />
+      <Suspense fallback={<div>{t('loading')}</div>}>
+        <TravelReportPageContent />
+      </Suspense>
     </PageWrapper>
   );
 }

--- a/src/components/pages/TravelReportPageContent.tsx
+++ b/src/components/pages/TravelReportPageContent.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import dayjs from 'dayjs';
 import { useTranslations } from 'next-intl';
@@ -77,10 +77,9 @@ export default function TravelReportPageContent() {
   );
 
   return (
-    <Suspense fallback={<div>{t('loading')}</div>}>
-      <div className='max-w-2xl mx-auto'>
-        <Card className='rounded-3xl border border-gray-200 dark:border-white/10 bg-gradient-to-tr from-indigo-200/30 via-sky-100/20 to-white/30 dark:from-indigo-500/30 dark:via-sky-500/10 dark:to-slate-900/20 shadow-2xl p-4'>
-          <CardContent className='p-2 space-y-6'>
+    <div className='max-w-2xl mx-auto'>
+      <Card className='rounded-3xl border border-gray-200 dark:border-white/10 bg-gradient-to-tr from-indigo-200/30 via-sky-100/20 to-white/30 dark:from-indigo-500/30 dark:via-sky-500/10 dark:to-slate-900/20 shadow-2xl p-4'>
+        <CardContent className='p-2 space-y-6'>
             <div className='flex items-center justify-between mb-6'>
               <h1 className='text-3xl font-bold flex items-center gap-3'>
                 <MapPin className='w-8 h-8 text-indigo-600 dark:text-indigo-300' />
@@ -156,7 +155,6 @@ export default function TravelReportPageContent() {
             </div>
           </CardContent>
         </Card>
-      </div>
-    </Suspense>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- wrap travel report content in a Suspense boundary with a translated fallback
- simplify travel report page content by removing internal Suspense

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68beee79c450832788de07c07402475a