### PR TITLE
feat: add payment method selector and icons

### DIFF
--- a/src/components/TransactionForm.tsx
+++ b/src/components/TransactionForm.tsx
@@ -28,6 +28,7 @@ import { useTranslations } from 'next-intl';
 import ClientModal from '@/components/ClientModal';
 import { getSettings } from '@/utils/settingsStorage';
 import { cnjoin } from '@/lib/utils';
+import PAYMENT_METHOD_STYLES from '@/utils/paymentMethodStyles';
 
 const pad = (n: number) => n.toString().padStart(2, '0');
 const formatDate = (d: Date) => `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
@@ -614,36 +615,30 @@ export default function TransactionForm({
 
         <div>
           <Label className='py-2'>{t('paymentMethod')}</Label>
-          <div className='flex gap-2 mt-1'>
-            <Button
-              type='button'
-              variant='outline'
-              onClick={() => !readOnly && setPaymentMethod('cash')}
-              className={cnjoin(
-                'flex-1 justify-start',
-                paymentMethod === 'cash'
-                  ? 'bg-amber-100 dark:bg-amber-900 border-amber-200 dark:border-amber-800 text-amber-800 dark:text-amber-200'
-                  : '',
-              )}
-              disabled={readOnly}
-            >
-              <Banknote className='w-4 h-4 mr-2' /> {t('paymentCash')}
-            </Button>
-            <Button
-              type='button'
-              variant='outline'
-              onClick={() => !readOnly && setPaymentMethod('transfer')}
-              className={cnjoin(
-                'flex-1 justify-start',
-                paymentMethod === 'transfer'
-                  ? 'bg-violet-100 dark:bg-violet-900 border-violet-200 dark:border-violet-800 text-violet-800 dark:text-violet-200'
-                  : '',
-              )}
-              disabled={readOnly}
-            >
-              <CreditCard className='w-4 h-4 mr-2' /> {t('paymentTransfer')}
-            </Button>
-          </div>
+          <Select
+            value={paymentMethod}
+            onValueChange={(val: PaymentMethod) => setPaymentMethod(val)}
+            disabled={readOnly}
+          >
+            <SelectTrigger className={cnjoin('w-full justify-start mt-1', PAYMENT_METHOD_STYLES[paymentMethod].bg)}>
+              <div className='flex items-center gap-2'>
+                {paymentMethod === 'cash' ? (
+                  <Banknote className={cnjoin('w-4 h-4', PAYMENT_METHOD_STYLES.cash.text)} />
+                ) : (
+                  <CreditCard className={cnjoin('w-4 h-4', PAYMENT_METHOD_STYLES.transfer.text)} />
+                )}
+                <SelectValue placeholder={t('paymentMethod')} />
+              </div>
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value='cash'>
+                <Banknote className={cnjoin('w-4 h-4', PAYMENT_METHOD_STYLES.cash.text)} /> {t('paymentCash')}
+              </SelectItem>
+              <SelectItem value='transfer'>
+                <CreditCard className={cnjoin('w-4 h-4', PAYMENT_METHOD_STYLES.transfer.text)} /> {t('paymentTransfer')}
+              </SelectItem>
+            </SelectContent>
+          </Select>
         </div>
 
         <div className='text-xl font-semibold text-right text-green-700 dark:text-green-300'>

--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -16,10 +16,11 @@ import {
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import { Pencil, Trash, FileText } from 'lucide-react';
+import { Pencil, Trash, FileText, Banknote, CreditCard } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
+import PAYMENT_METHOD_STYLES from '@/utils/paymentMethodStyles';
 
 export default function TransactionList({ refresh }: { refresh: number }) {
   const t = useTranslations('transactionsList');
@@ -155,6 +156,11 @@ export default function TransactionList({ refresh }: { refresh: number }) {
                     >
                       {tx.status === 'finalised' ? t('finalised') : t('draft')}
                     </Badge>
+                    {tx.paymentMethod === 'cash' ? (
+                      <Banknote className={`w-4 h-4 ${PAYMENT_METHOD_STYLES.cash.text}`} />
+                    ) : (
+                      <CreditCard className={`w-4 h-4 ${PAYMENT_METHOD_STYLES.transfer.text}`} />
+                    )}
                   </div>
 
                   <div className='flex gap-2' onClick={e => e.stopPropagation()}>

--- a/src/utils/paymentMethodStyles.ts
+++ b/src/utils/paymentMethodStyles.ts
@@ -1,0 +1,14 @@
+import { PaymentMethod } from '@/types';
+
+export const PAYMENT_METHOD_STYLES: Record<PaymentMethod, { text: string; bg: string }> = {
+  cash: {
+    text: 'text-green-600 dark:text-green-400',
+    bg: 'bg-green-100 dark:bg-green-900 border-green-200 dark:border-green-800 text-green-800 dark:text-green-200',
+  },
+  transfer: {
+    text: 'text-blue-600 dark:text-blue-400',
+    bg: 'bg-blue-100 dark:bg-blue-900 border-blue-200 dark:border-blue-800 text-blue-800 dark:text-blue-200',
+  },
+};
+
+export default PAYMENT_METHOD_STYLES;


### PR DESCRIPTION
## Summary
- add centralized payment method colors
- display colored payment icons in transaction list
- switch payment form buttons to colored dropdown selector

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type.)*

------
https://chatgpt.com/codex/tasks/task_e_68c005293fe48327a0ba4d931ad2f7d4