### PR TITLE
Fix payment method handling and filter propagation

### DIFF
--- a/src/components/TransactionForm.tsx
+++ b/src/components/TransactionForm.tsx
@@ -67,6 +67,9 @@ export default function TransactionForm({
   const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>('cash');
   const { currency } = getSettings();
 
+  const isValidPaymentMethod = (m: unknown): m is PaymentMethod => m === 'cash' || m === 'transfer';
+  const paymentStyle = PAYMENT_METHOD_STYLES[paymentMethod] || PAYMENT_METHOD_STYLES.cash;
+
   const combineDateTime = (date: string, time: string) => {
     const timePart = time || initialTime || '00:00';
     return `${date}T${timePart}`;
@@ -118,7 +121,9 @@ export default function TransactionForm({
       const timeValue = timePart.slice(0, 5);
       setTransactionTime(timeValue);
       setInitialTime(timeValue);
-      setPaymentMethod(editingTransaction.paymentMethod ?? 'cash');
+      setPaymentMethod(
+        isValidPaymentMethod(editingTransaction.paymentMethod) ? editingTransaction.paymentMethod : 'cash'
+      );
     }
     if (!editingTransaction) {
       const now = new Date();
@@ -637,7 +642,7 @@ export default function TransactionForm({
             onValueChange={(val: PaymentMethod) => setPaymentMethod(val)}
             disabled={readOnly}
           >
-            <SelectTrigger className={cnjoin('w-full justify-start mt-1', PAYMENT_METHOD_STYLES[paymentMethod].bg)}>
+            <SelectTrigger className={cnjoin('w-full justify-start mt-1', paymentStyle.bg)}>
               <SelectValue placeholder={t('paymentMethod')} />
             </SelectTrigger>
             <SelectContent>

--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -22,7 +22,13 @@ import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import PAYMENT_METHOD_STYLES from '@/utils/paymentMethodStyles';
 
-export default function TransactionList({ refresh }: { refresh: number }) {
+interface TransactionListProps {
+  refresh: number;
+  paymentFilter: 'all' | PaymentMethod;
+  onPaymentFilterChange: (val: 'all' | PaymentMethod) => void;
+}
+
+export default function TransactionList({ refresh, paymentFilter, onPaymentFilterChange }: TransactionListProps) {
   const t = useTranslations('transactionsList');
   const tForm = useTranslations('transactionForm');
   const [transactions, setTransactions] = useState<Transaction[]>([]);
@@ -30,7 +36,6 @@ export default function TransactionList({ refresh }: { refresh: number }) {
   const [search, setSearch] = useState('');
   const [sortField, setSortField] = useState<'date' | 'client'>('date');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
-  const [paymentFilter, setPaymentFilter] = useState<'all' | PaymentMethod>('all');
   const [selectedTx, setSelectedTx] = useState<Transaction | null>(null);
   const router = useRouter();
 
@@ -75,7 +80,7 @@ export default function TransactionList({ refresh }: { refresh: number }) {
           />
 
           <div className='flex flex-row gap-2 md:items-center'>
-            <Select value={paymentFilter} onValueChange={(val: 'all' | PaymentMethod) => setPaymentFilter(val)}>
+            <Select value={paymentFilter} onValueChange={onPaymentFilterChange}>
               <SelectTrigger className='w-[110px] md:w-[110px]'>
                 <SelectValue placeholder={tForm('paymentMethod')} />
               </SelectTrigger>

--- a/src/components/pages/TransactionsPageContent.tsx
+++ b/src/components/pages/TransactionsPageContent.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense, useState } from 'react';
+import { Suspense, useState, useEffect } from 'react';
 import useDataUpdate from '@/utils/useDataUpdate';
 import Link from 'next/link';
 import { PlusCircle, ReceiptText, FileDown, MapPin } from 'lucide-react';
@@ -31,8 +31,14 @@ export default function TransactionsPage() {
   const router = useRouter();
   const [expRange, setExpRange] = useState<DateRange | undefined>();
   const [repRange, setRepRange] = useState<DateRange | undefined>();
+  const [paymentFilter, setPaymentFilter] = useState<'all' | PaymentMethod>('all');
   const [expMethod, setExpMethod] = useState<'all' | PaymentMethod>('all');
   const [repMethod, setRepMethod] = useState<'all' | PaymentMethod>('all');
+
+  useEffect(() => {
+    setExpMethod(paymentFilter);
+    setRepMethod(paymentFilter);
+  }, [paymentFilter]);
 
   const exportLabels = {
     header: pdfT('header'),
@@ -187,6 +193,7 @@ export default function TransactionsPage() {
                           const params = new URLSearchParams();
                           if (from) params.set('from', from);
                           if (to) params.set('to', to);
+                          if (repMethod !== 'all') params.set('method', repMethod);
                           router.push(`/transactions/travel-report?${params.toString()}`);
                         }}
                       >
@@ -204,7 +211,11 @@ export default function TransactionsPage() {
               </div>
             </div>
 
-            <TransactionList refresh={refresh} />
+            <TransactionList
+              refresh={refresh}
+              paymentFilter={paymentFilter}
+              onPaymentFilterChange={setPaymentFilter}
+            />
           </CardContent>
         </Card>
       </div>

--- a/src/components/pages/TravelReportPageContent.tsx
+++ b/src/components/pages/TravelReportPageContent.tsx
@@ -16,6 +16,7 @@ import { toast } from 'sonner';
 import Link from 'next/link';
 import { ArrowLeft } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { PaymentMethod } from '@/types';
 
 interface TravelRow {
   date: string;
@@ -31,6 +32,7 @@ export default function TravelReportPageContent() {
   const params = useSearchParams();
   const from = params.get('from');
   const to = params.get('to');
+  const method = params.get('method') as PaymentMethod | null;
   const [rows, setRows] = useState<TravelRow[]>([]);
   const { distanceUnit, currency } = getSettings();
 
@@ -40,7 +42,11 @@ export default function TravelReportPageContent() {
     const clients = getClients();
     const filtered = txs.filter(tx => {
       const d = dayjs(tx.date);
-      return (!from || d.isAfter(dayjs(from).subtract(1, 'day'))) && (!to || d.isBefore(dayjs(to).add(1, 'day')));
+      return (
+        (!from || d.isAfter(dayjs(from).subtract(1, 'day'))) &&
+        (!to || d.isBefore(dayjs(to).add(1, 'day'))) &&
+        (!method || tx.paymentMethod === method)
+      );
     });
     const data: TravelRow[] = [];
     filtered.forEach(tx => {
@@ -63,7 +69,7 @@ export default function TravelReportPageContent() {
     if (data.length === 0) {
       toast.error(t('noData'));
     }
-  }, [from, to, listT, itemTypeT, distanceUnit, t]);
+  }, [from, to, method, listT, itemTypeT, distanceUnit, t]);
 
   const totalDistance = rows.reduce((sum, r) => sum + r.distance, 0);
   const totalValue = rows.reduce((sum, r) => sum + r.value, 0);


### PR DESCRIPTION
## Summary
- validate transaction payment method and default styling to avoid runtime errors
- sync payment method filter with PDF and travel reports
- include payment method in travel report query parameters

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c01a874f74832787302ffd5c5aa765