### PR TITLE
Fix payment method select shows placeholder

### DIFF
--- a/src/components/TransactionForm.tsx
+++ b/src/components/TransactionForm.tsx
@@ -646,10 +646,10 @@ export default function TransactionForm({
               <SelectValue placeholder={t('paymentMethod')} />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value='cash'>
+              <SelectItem value='cash' textValue={t('paymentCash')}>
                 <Banknote className={cnjoin('w-4 h-4', PAYMENT_METHOD_STYLES.cash.text)} /> {t('paymentCash')}
               </SelectItem>
-              <SelectItem value='transfer'>
+              <SelectItem value='transfer' textValue={t('paymentTransfer')}>
                 <CreditCard className={cnjoin('w-4 h-4', PAYMENT_METHOD_STYLES.transfer.text)} /> {t('paymentTransfer')}
               </SelectItem>
             </SelectContent>


### PR DESCRIPTION
## Summary
- ensure payment method select displays current or default value by adding textValue to items

## Testing
- `npm test` (fails: jest not found)
- `npm install --legacy-peer-deps` (fails: network aborted)


------
https://chatgpt.com/codex/tasks/task_e_68c0263cfe048327b1efbed45e66b08c