### PR TITLE
Ensure product unit loads during editing

### DIFF
--- a/src/components/ProductForm.tsx
+++ b/src/components/ProductForm.tsx
@@ -6,7 +6,7 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { getProducts, saveProduct } from '@/utils/productStorage';
-import { Unit, ItemType, Product } from '@/types';
+import { Unit, ItemType } from '@/types';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
 import { useTranslations } from 'next-intl';
 
@@ -23,7 +23,6 @@ export default function ProductForm({ onAdd }: { onAdd: () => void }) {
     'ampoule', 'sachet', 'blister', 'tube', 'tubosyringe', 'can', 'km',
   ], []);
 
-  const [product, setProduct] = useState<Product | null>(null);
   const [name, setName] = useState('');
   const [unit, setUnit] = useState<Unit>('pcs');
   const [customUnit, setCustomUnit] = useState('');
@@ -35,24 +34,26 @@ export default function ProductForm({ onAdd }: { onAdd: () => void }) {
     if (!productId) return;
 
     const prod = getProducts().find(p => p.id === productId);
-    if (prod) setProduct(prod);
-  }, [productId]);
+    if (!prod) return;
 
-  useEffect(() => {
-    if (!product) return;
-    setName(product.name);
-    setPrice(product.pricePerUnit.toString());
-    setType(product.type || 'product');
+    setName(prod.name);
+    setPrice(prod.pricePerUnit.toString());
+    setType(prod.type || 'product');
 
-    if (predefinedUnits.includes(product.unit)) {
-      setUnit(product.unit as Unit);
+    const normalizedUnit = prod.unit?.toLowerCase().trim();
+    if (normalizedUnit && predefinedUnits.includes(normalizedUnit as Unit)) {
+      setUnit(normalizedUnit as Unit);
       setIsCustomUnit(false);
       setCustomUnit('');
-    } else {
+    } else if (prod.unit) {
       setIsCustomUnit(true);
-      setCustomUnit(product.unit);
+      setCustomUnit(prod.unit);
+    } else {
+      setUnit('pcs');
+      setIsCustomUnit(false);
+      setCustomUnit('');
     }
-  }, [product, predefinedUnits]);
+  }, [productId, predefinedUnits]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/utils/normalizeProduct.ts
+++ b/src/utils/normalizeProduct.ts
@@ -1,0 +1,10 @@
+import type { Product } from '@/types'
+
+export function normalizeProduct(p: Product): Product {
+  return {
+    ...p,
+    type: p.type ?? 'product',
+    unit: p.unit?.trim() || 'pcs',
+  }
+}
+

--- a/src/utils/productStorage.ts
+++ b/src/utils/productStorage.ts
@@ -2,10 +2,7 @@ import { Product } from '@/types'
 import { queueOperation } from './syncSupabase'
 import { notifyDataUpdated } from './dataUpdateEvent'
 import { storageKey } from './userStorage'
-
-export function normalizeProduct(p: Product): Product {
-  return { ...p, type: p.type ?? 'product' }
-}
+import { normalizeProduct } from './normalizeProduct'
 
 const BASE_KEY = 'vet_products'
 const STORAGE_KEY = () => storageKey(BASE_KEY)

--- a/tests/productStorage.test.ts
+++ b/tests/productStorage.test.ts
@@ -1,0 +1,25 @@
+import { normalizeProduct } from '../src/utils/normalizeProduct'
+import { Product } from '../src/types'
+
+describe('normalizeProduct', () => {
+  it('fills missing type and unit', () => {
+    const product = { id: '1', name: 'A', pricePerUnit: 1, unit: '' } as Product
+    expect(normalizeProduct(product)).toEqual({
+      ...product,
+      type: 'product',
+      unit: 'pcs',
+    })
+  })
+
+  it('trims provided unit', () => {
+    const product = {
+      id: '2',
+      name: 'B',
+      pricePerUnit: 1,
+      unit: ' ml ',
+      type: 'service',
+    } as Product
+    expect(normalizeProduct(product).unit).toBe('ml')
+  })
+})
+


### PR DESCRIPTION
## Summary
- load product details and set unit field when editing, defaulting to `pcs` when missing
- centralize product normalization with unit trimming and defaults
- test product normalization for missing or trimmed units

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c02acbe660832790805c8c57dd474d