### PR TITLE
Handle localized unit names in product editing

### DIFF
--- a/src/components/ProductForm.tsx
+++ b/src/components/ProductForm.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { getProducts, saveProduct } from '@/utils/productStorage';
 import { Unit, ItemType } from '@/types';
+import { predefinedUnits, mapUnit } from '@/utils/unit';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
 import { useTranslations } from 'next-intl';
 
@@ -17,11 +18,6 @@ export default function ProductForm({ onAdd }: { onAdd: () => void }) {
 
   const t = useTranslations('ProductForm');
   const unitT = useTranslations('unit');
-
-  const predefinedUnits: Unit[] = useMemo(() => [
-    'pcs', 'ml', 'g', 'kg', 'pack', 'dose', 'tablet', 'dropper',
-    'ampoule', 'sachet', 'blister', 'tube', 'tubosyringe', 'can', 'km',
-  ], []);
 
   const [name, setName] = useState('');
   const [unit, setUnit] = useState<Unit>('pcs');
@@ -40,9 +36,9 @@ export default function ProductForm({ onAdd }: { onAdd: () => void }) {
     setPrice(prod.pricePerUnit.toString());
     setType(prod.type || 'product');
 
-    const normalizedUnit = prod.unit?.toLowerCase().trim();
-    if (normalizedUnit && predefinedUnits.includes(normalizedUnit as Unit)) {
-      setUnit(normalizedUnit as Unit);
+    const mapped = mapUnit(prod.unit);
+    if (mapped) {
+      setUnit(mapped);
       setIsCustomUnit(false);
       setCustomUnit('');
     } else if (prod.unit) {
@@ -53,7 +49,7 @@ export default function ProductForm({ onAdd }: { onAdd: () => void }) {
       setIsCustomUnit(false);
       setCustomUnit('');
     }
-  }, [productId, predefinedUnits]);
+  }, [productId]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/components/ProductList.tsx
+++ b/src/components/ProductList.tsx
@@ -11,6 +11,7 @@ import { Pencil, Trash } from 'lucide-react';
 import { getProducts, deleteProduct } from '@/utils/productStorage';
 import { Product, ItemType, Unit } from '@/types';
 import { useTranslations } from 'next-intl';
+import { translateUnit } from '@/utils/unit';
 
 export default function ProductList({ refresh }: { refresh: number }) {
   const t = useTranslations('productList');
@@ -134,7 +135,7 @@ export default function ProductList({ refresh }: { refresh: number }) {
                     <span className='font-medium text-foreground'>{t('type')}:</span> {itemTypeT(p.type)}
                   </div>
                   <div>
-                    <span className='font-medium text-foreground'>{t('unit')}:</span> {unitT(p.unit)}
+                    <span className='font-medium text-foreground'>{t('unit')}:</span> {translateUnit(p.unit, unitT)}
                   </div>
                   <div>
                     <span className='font-medium text-foreground'>{t('price')}:</span> {p.pricePerUnit.toFixed(2)} zł

--- a/src/public/locales/en.json
+++ b/src/public/locales/en.json
@@ -14,6 +14,7 @@
     "tube": "tube",
     "tubosyringe": "tubosyringe",
     "can": "can",
+    "bottle": "bottle",
     "km": "km"
   },
   "itemType": {

--- a/src/public/locales/pl.json
+++ b/src/public/locales/pl.json
@@ -14,6 +14,7 @@
     "tube": "tuba",
     "tubosyringe": "tubostrz.",
     "can": "puszka",
+    "bottle": "butelka",
     "km": "km"
   },
   "itemType": {

--- a/src/utils/unit.ts
+++ b/src/utils/unit.ts
@@ -1,0 +1,50 @@
+import en from '../public/locales/en.json'
+import pl from '../public/locales/pl.json'
+import { Unit } from '@/types'
+
+export const predefinedUnits: Unit[] = [
+  'pcs',
+  'ml',
+  'g',
+  'kg',
+  'pack',
+  'dose',
+  'tablet',
+  'dropper',
+  'ampoule',
+  'sachet',
+  'blister',
+  'tube',
+  'tubosyringe',
+  'can',
+  'km',
+]
+
+const unitMap: Record<string, Unit> = {}
+
+const allUnitKeys = new Set(
+  Object.keys(en.unit as Record<string, string>).concat(
+    Object.keys(pl.unit as Record<string, string>),
+  ),
+)
+
+predefinedUnits.forEach(u => {
+  unitMap[u] = u
+  const enName = (en.unit as Record<string, string>)[u]
+  const plName = (pl.unit as Record<string, string>)[u]
+  if (enName) unitMap[enName.toLowerCase()] = u
+  if (plName) unitMap[plName.toLowerCase()] = u
+})
+
+export function mapUnit(value?: string): Unit | undefined {
+  if (!value) return undefined
+  return unitMap[value.toLowerCase().trim()]
+}
+
+export function translateUnit(value: string, t: (key: string) => string): string {
+  const canonical = mapUnit(value)
+  if (canonical) return t(canonical)
+  const key = value.toLowerCase().trim()
+  if (allUnitKeys.has(key)) return t(key)
+  return value
+}

--- a/tests/locales.test.ts
+++ b/tests/locales.test.ts
@@ -1,0 +1,9 @@
+import pl from '../src/public/locales/pl.json'
+import en from '../src/public/locales/en.json'
+
+describe('locale messages', () => {
+  it('provides translation for unit.bottle', () => {
+    expect(pl.unit.bottle).toBe('butelka')
+    expect(en.unit.bottle).toBe('bottle')
+  })
+})

--- a/tests/unitMapping.test.ts
+++ b/tests/unitMapping.test.ts
@@ -1,0 +1,23 @@
+import { mapUnit, translateUnit } from '../src/utils/unit'
+import pl from '../src/public/locales/pl.json'
+import en from '../src/public/locales/en.json'
+
+describe('unit mapping', () => {
+  const plT = (k: string) => (pl.unit as Record<string, string>)[k]
+  const enT = (k: string) => (en.unit as Record<string, string>)[k]
+
+  it('maps polish and english names to canonical units', () => {
+    expect(mapUnit('pcs')).toBe('pcs')
+    expect(mapUnit('szt')).toBe('pcs')
+    expect(mapUnit('bottle')).toBeUndefined()
+    expect(mapUnit('unknown')).toBeUndefined()
+  })
+
+  it('translates known units and falls back for custom ones', () => {
+    expect(translateUnit('pcs', plT)).toBe('szt')
+    expect(translateUnit('szt', plT)).toBe('szt')
+    expect(translateUnit('bottle', plT)).toBe('butelka')
+    expect(translateUnit('bottle', enT)).toBe('bottle')
+    expect(translateUnit('custom', enT)).toBe('custom')
+  })
+})


### PR DESCRIPTION
## Summary
- map stored product units to English keys so editing shows the correct unit regardless of locale
- display translated units only when available and fall back to the user’s value for custom units
- cover unit mapping with tests
- rename `butelka` unit key to `bottle` and translate it to Polish

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c02de971a88327bdf129eec11581d1