### PR TITLE
Add detailed dashboard summaries for items, discounts and fees

### DIFF
--- a/src/public/locales/en.json
+++ b/src/public/locales/en.json
@@ -69,6 +69,10 @@
       "transactions": "Transactions",
       "clients": "Clients",
       "totalValue": "Total Value",
+      "productsValue": "Products Value",
+      "servicesValue": "Services Value",
+      "discounts": "Discounts",
+      "additionalFees": "Additional Fees",
       "avgPerTransaction": "Avg per Transaction"
     },
     "charts": {

--- a/src/public/locales/pl.json
+++ b/src/public/locales/pl.json
@@ -69,6 +69,10 @@
       "transactions": "Rozliczenia",
       "clients": "Klienci",
       "totalValue": "Łączna wartość",
+      "productsValue": "Wartość produktów",
+      "servicesValue": "Wartość usług",
+      "discounts": "Rabaty",
+      "additionalFees": "Dodatkowe opłaty",
       "avgPerTransaction": "Śr. na rozliczenie"
     },
     "charts": {


### PR DESCRIPTION
## Summary
- summarize product and service item totals on dashboard
- track aggregated discounts and additional fees in dashboard summary
- localize new dashboard summary labels

## Testing
- `npm test`
- `npm run lint` *(fails: Bus error)*

------
https://chatgpt.com/codex/tasks/task_e_68c143e0670883278d725a470d74958c